### PR TITLE
Add core library and app framework foundation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,103 @@
+import { type AppDesc, type AppEvent, AppEventType } from "./types.js";
+import { createGfx } from "./gfx.js";
+
+export async function run(desc: AppDesc): Promise<() => void> {
+  const canvas = typeof desc.canvas === "string"
+    ? document.querySelector<HTMLCanvasElement>(desc.canvas)!
+    : desc.canvas;
+
+  if (!canvas) throw new Error("Canvas not found");
+
+  if (!navigator.gpu) {
+    throw new Error("WebGPU is not supported in this browser");
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) throw new Error("Failed to get GPU adapter");
+
+  const device = await adapter.requestDevice();
+  const context = canvas.getContext("webgpu")!;
+  const format = navigator.gpu.getPreferredCanvasFormat();
+
+  context.configure({ device, format, alphaMode: "premultiplied" });
+
+  const pixelRatio = desc.pixelRatio ?? window.devicePixelRatio;
+
+  function resize() {
+    const w = Math.floor(canvas.clientWidth * pixelRatio);
+    const h = Math.floor(canvas.clientHeight * pixelRatio);
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+  }
+
+  resize();
+
+  const gfx = createGfx(device, canvas, context, format);
+
+  await desc.init(gfx);
+
+  // Input events
+  function dispatch(ev: AppEvent) {
+    desc.event?.(ev, gfx);
+  }
+
+  const eventMap: [EventTarget, string, (e: Event) => void][] = [];
+
+  function listen<K extends keyof HTMLElementEventMap>(
+    target: EventTarget,
+    type: K,
+    handler: (e: HTMLElementEventMap[K]) => void,
+  ) {
+    const h = handler as (e: Event) => void;
+    target.addEventListener(type, h);
+    eventMap.push([target, type, h]);
+  }
+
+  listen(canvas, "mousedown", (e) => dispatch({ type: AppEventType.MOUSE_DOWN, mouseX: e.offsetX * pixelRatio, mouseY: e.offsetY * pixelRatio, mouseButton: e.button }));
+  listen(canvas, "mouseup", (e) => dispatch({ type: AppEventType.MOUSE_UP, mouseX: e.offsetX * pixelRatio, mouseY: e.offsetY * pixelRatio, mouseButton: e.button }));
+  listen(canvas, "mousemove", (e) => dispatch({ type: AppEventType.MOUSE_MOVE, mouseX: e.offsetX * pixelRatio, mouseY: e.offsetY * pixelRatio, deltaX: e.movementX, deltaY: e.movementY }));
+  listen(canvas, "wheel", (e) => { e.preventDefault(); dispatch({ type: AppEventType.MOUSE_WHEEL, deltaX: (e as WheelEvent).deltaX, deltaY: (e as WheelEvent).deltaY }); }, );
+  listen(window, "keydown", (e) => dispatch({ type: AppEventType.KEY_DOWN, key: (e as KeyboardEvent).key, code: (e as KeyboardEvent).code }));
+  listen(window, "keyup", (e) => dispatch({ type: AppEventType.KEY_UP, key: (e as KeyboardEvent).key, code: (e as KeyboardEvent).code }));
+
+  listen(canvas, "touchstart", (e) => {
+    e.preventDefault();
+    dispatch({ type: AppEventType.TOUCH_START, touches: Array.from((e as TouchEvent).touches).map(t => ({ id: t.identifier, x: t.clientX * pixelRatio, y: t.clientY * pixelRatio })) });
+  });
+  listen(canvas, "touchmove", (e) => {
+    e.preventDefault();
+    dispatch({ type: AppEventType.TOUCH_MOVE, touches: Array.from((e as TouchEvent).touches).map(t => ({ id: t.identifier, x: t.clientX * pixelRatio, y: t.clientY * pixelRatio })) });
+  });
+  listen(canvas, "touchend", (e) => {
+    dispatch({ type: AppEventType.TOUCH_END, touches: Array.from((e as TouchEvent).changedTouches).map(t => ({ id: t.identifier, x: t.clientX * pixelRatio, y: t.clientY * pixelRatio })) });
+  });
+
+  const resizeObserver = new ResizeObserver(() => {
+    resize();
+    dispatch({ type: AppEventType.RESIZE, width: canvas.width, height: canvas.height });
+  });
+  resizeObserver.observe(canvas);
+
+  // Frame loop
+  let running = true;
+  function frame() {
+    if (!running) return;
+    resize();
+    desc.frame(gfx);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+
+  // Return cleanup function
+  return () => {
+    running = false;
+    resizeObserver.disconnect();
+    for (const [target, type, handler] of eventMap) {
+      target.removeEventListener(type, handler);
+    }
+    desc.cleanup?.(gfx);
+    device.destroy();
+  };
+}

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1,0 +1,354 @@
+import {
+  type SgBuffer, type SgImage, type SgSampler, type SgShader, type SgPipeline,
+  type BufferDesc, type ImageDesc, type SamplerDesc, type ShaderDesc, type PipelineDesc,
+  type Bindings, type PassDesc, type Gfx,
+  BufferUsage, IndexType, LoadAction, PixelFormat, PrimitiveType, CullMode, CompareFunc,
+  FilterMode, WrapMode,
+} from "./types.js";
+
+let nextId = 1;
+function handle<T extends { readonly _brand: string; readonly id: number }>(brand: string): T {
+  return { _brand: brand, id: nextId++ } as unknown as T;
+}
+
+interface BufferSlot {
+  gpu: GPUBuffer;
+  desc: BufferDesc;
+}
+
+interface ImageSlot {
+  texture: GPUTexture;
+  view: GPUTextureView;
+  desc: ImageDesc;
+}
+
+interface SamplerSlot {
+  gpu: GPUSampler;
+}
+
+interface ShaderSlot {
+  vertexModule: GPUShaderModule;
+  fragmentModule: GPUShaderModule;
+  vertexSource: string;
+  fragmentSource: string;
+}
+
+interface PipelineSlot {
+  gpu: GPURenderPipeline;
+  desc: PipelineDesc;
+  indexType: IndexType;
+}
+
+export function createGfx(
+  device: GPUDevice,
+  canvas: HTMLCanvasElement,
+  context: GPUCanvasContext,
+  format: GPUTextureFormat,
+): Gfx {
+  const buffers = new Map<number, BufferSlot>();
+  const images = new Map<number, ImageSlot>();
+  const samplers = new Map<number, SamplerSlot>();
+  const shaders = new Map<number, ShaderSlot>();
+  const pipelines = new Map<number, PipelineSlot>();
+
+  // Per-frame state
+  let encoder: GPUCommandEncoder | null = null;
+  let passEncoder: GPURenderPassEncoder | null = null;
+  let currentPipeline: PipelineSlot | null = null;
+  let frameTime = 0;
+  let lastFrameTime = 0;
+  let _frameCount = 0;
+  let uniformOffset = 0;
+  let uniformBuffer: GPUBuffer | null = null;
+  let uniformBindGroup: GPUBindGroup | null = null;
+
+  const UNIFORM_BUFFER_SIZE = 65536; // 64KB uniform staging
+
+  function ensureUniformBuffer() {
+    if (!uniformBuffer) {
+      uniformBuffer = device.createBuffer({
+        size: UNIFORM_BUFFER_SIZE,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      });
+    }
+    return uniformBuffer;
+  }
+
+  function gpuBufferUsage(usage: BufferUsage | undefined): number {
+    const base = GPUBufferUsage.COPY_DST;
+    switch (usage) {
+      default: return base | GPUBufferUsage.VERTEX | GPUBufferUsage.INDEX;
+    }
+  }
+
+  const gfx: Gfx = {
+    get canvas() { return canvas; },
+    get device() { return device; },
+    get width() { return canvas.width; },
+    get height() { return canvas.height; },
+    get dt() { return frameTime; },
+    get frameCount() { return _frameCount; },
+
+    makeBuffer(desc: BufferDesc): SgBuffer {
+      const h = handle<SgBuffer>("SgBuffer");
+      const size = desc.data ? desc.data.byteLength : (desc.size ?? 256);
+      const gpu = device.createBuffer({
+        size,
+        usage: gpuBufferUsage(desc.usage),
+        mappedAtCreation: !!desc.data,
+        label: desc.label,
+      });
+      if (desc.data) {
+        new Uint8Array(gpu.getMappedRange()).set(new Uint8Array(desc.data.buffer, desc.data.byteOffset, desc.data.byteLength));
+        gpu.unmap();
+      }
+      buffers.set(h.id, { gpu, desc });
+      return h;
+    },
+
+    makeImage(desc: ImageDesc): SgImage {
+      const h = handle<SgImage>("SgImage");
+      const fmt = (desc.format ?? PixelFormat.RGBA8) as GPUTextureFormat;
+      let usage = GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST;
+      if (desc.renderTarget) {
+        usage |= GPUTextureUsage.RENDER_ATTACHMENT;
+      }
+      const texture = device.createTexture({
+        size: { width: desc.width, height: desc.height },
+        format: fmt,
+        usage,
+        label: desc.label,
+      });
+      if (desc.data) {
+        device.queue.writeTexture(
+          { texture },
+          desc.data,
+          { bytesPerRow: desc.width * 4 },
+          { width: desc.width, height: desc.height },
+        );
+      }
+      images.set(h.id, { texture, view: texture.createView(), desc });
+      return h;
+    },
+
+    makeSampler(desc: SamplerDesc): SgSampler {
+      const h = handle<SgSampler>("SgSampler");
+      const gpu = device.createSampler({
+        minFilter: desc.minFilter ?? FilterMode.NEAREST,
+        magFilter: desc.magFilter ?? FilterMode.NEAREST,
+        mipmapFilter: desc.mipmapFilter ?? FilterMode.NEAREST,
+        addressModeU: desc.wrapU ?? WrapMode.REPEAT,
+        addressModeV: desc.wrapV ?? WrapMode.REPEAT,
+        compare: desc.compare as GPUCompareFunction | undefined,
+        label: desc.label,
+      });
+      samplers.set(h.id, { gpu });
+      return h;
+    },
+
+    makeShader(desc: ShaderDesc): SgShader {
+      const h = handle<SgShader>("SgShader");
+      const vertexModule = device.createShaderModule({ code: desc.vertexSource, label: desc.label ? `${desc.label}_vs` : undefined });
+      const fragmentModule = device.createShaderModule({ code: desc.fragmentSource, label: desc.label ? `${desc.label}_fs` : undefined });
+      shaders.set(h.id, { vertexModule, fragmentModule, vertexSource: desc.vertexSource, fragmentSource: desc.fragmentSource });
+      return h;
+    },
+
+    makePipeline(desc: PipelineDesc): SgPipeline {
+      const h = handle<SgPipeline>("SgPipeline");
+      const shd = shaders.get(desc.shader.id);
+      if (!shd) throw new Error("Invalid shader handle");
+
+      const vertexBuffers: GPUVertexBufferLayout[] = desc.layout.buffers.map((buf, i) => ({
+        arrayStride: buf.stride,
+        stepMode: buf.stepMode ?? "vertex",
+        attributes: desc.layout.attrs
+          .filter(a => (a.bufferIndex ?? 0) === i)
+          .map(a => ({
+            format: a.format as GPUVertexFormat,
+            offset: a.offset ?? 0,
+            shaderLocation: a.shaderLocation,
+          })),
+      }));
+
+      const colorTargets: GPUColorTargetState[] = (desc.colors ?? [{}]).map(c => ({
+        format: (c.format as GPUTextureFormat) ?? format,
+        blend: c.blendEnabled ? {
+          color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
+          alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
+        } as GPUBlendState : undefined,
+      }));
+
+      const bindGroupLayouts: GPUBindGroupLayout[] = [];
+
+      // Group 0: uniform buffer (always present)
+      bindGroupLayouts.push(device.createBindGroupLayout({
+        entries: [{
+          binding: 0,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform", hasDynamicOffset: true },
+        }],
+      }));
+
+      // Group 1: textures + samplers (if any)
+      // Users can extend this via custom bind group layouts later
+
+      const pipelineLayout = device.createPipelineLayout({
+        bindGroupLayouts,
+      });
+
+      const gpuPipeline = device.createRenderPipeline({
+        layout: pipelineLayout,
+        vertex: {
+          module: shd.vertexModule,
+          entryPoint: "vs_main",
+          buffers: vertexBuffers,
+        },
+        fragment: {
+          module: shd.fragmentModule,
+          entryPoint: "fs_main",
+          targets: colorTargets,
+        },
+        primitive: {
+          topology: (desc.primitive ?? PrimitiveType.TRIANGLES) as GPUPrimitiveTopology,
+          cullMode: (desc.cullMode ?? CullMode.NONE) as GPUCullMode,
+          stripIndexFormat: desc.primitive === PrimitiveType.TRIANGLE_STRIP || desc.primitive === PrimitiveType.LINE_STRIP
+            ? (desc.indexType === IndexType.UINT32 ? "uint32" : "uint16")
+            : undefined,
+        },
+        depthStencil: desc.depth ? {
+          format: (desc.depth.format ?? PixelFormat.DEPTH24_STENCIL8) as GPUTextureFormat,
+          depthWriteEnabled: desc.depth.depthWrite ?? true,
+          depthCompare: (desc.depth.depthCompare ?? CompareFunc.LESS) as GPUCompareFunction,
+        } : undefined,
+        label: desc.label,
+      });
+
+      pipelines.set(h.id, { gpu: gpuPipeline, desc, indexType: desc.indexType ?? IndexType.NONE });
+      return h;
+    },
+
+    destroyBuffer(buf: SgBuffer) {
+      const slot = buffers.get(buf.id);
+      if (slot) { slot.gpu.destroy(); buffers.delete(buf.id); }
+    },
+    destroyImage(img: SgImage) {
+      const slot = images.get(img.id);
+      if (slot) { slot.texture.destroy(); images.delete(img.id); }
+    },
+    destroySampler(smp: SgSampler) { samplers.delete(smp.id); },
+    destroyShader(shd: SgShader) { shaders.delete(shd.id); },
+    destroyPipeline(pip: SgPipeline) { pipelines.delete(pip.id); },
+
+    updateBuffer(buf: SgBuffer, data: ArrayBufferView) {
+      const slot = buffers.get(buf.id);
+      if (!slot) throw new Error("Invalid buffer handle");
+      device.queue.writeBuffer(slot.gpu, 0, data.buffer, data.byteOffset, data.byteLength);
+    },
+
+    beginPass(desc?: PassDesc) {
+      encoder = device.createCommandEncoder();
+
+      const colorAttachments: GPURenderPassColorAttachment[] = [];
+
+      if (desc?.offscreen) {
+        for (let i = 0; i < desc.offscreen.colorImages.length; i++) {
+          const img = images.get(desc.offscreen.colorImages[i].id);
+          if (!img) throw new Error("Invalid offscreen color image");
+          const ca = desc.colorAttachments?.[i];
+          colorAttachments.push({
+            view: img.view,
+            loadOp: ca?.action === LoadAction.LOAD ? "load" : "clear",
+            storeOp: "store",
+            clearValue: ca?.color ? { r: ca.color[0], g: ca.color[1], b: ca.color[2], a: ca.color[3] } : { r: 0, g: 0, b: 0, a: 1 },
+          });
+        }
+      } else {
+        const ca = desc?.colorAttachments?.[0];
+        const textureView = context.getCurrentTexture().createView();
+        colorAttachments.push({
+          view: textureView,
+          loadOp: ca?.action === LoadAction.LOAD ? "load" : "clear",
+          storeOp: "store",
+          clearValue: ca?.color ? { r: ca.color[0], g: ca.color[1], b: ca.color[2], a: ca.color[3] } : { r: 0, g: 0, b: 0, a: 1 },
+        });
+      }
+
+      const passDesc: GPURenderPassDescriptor = { colorAttachments };
+
+      passEncoder = encoder.beginRenderPass(passDesc);
+      uniformOffset = 0;
+    },
+
+    applyPipeline(pip: SgPipeline) {
+      const slot = pipelines.get(pip.id);
+      if (!slot || !passEncoder) throw new Error("Invalid pipeline or no active pass");
+      passEncoder.setPipeline(slot.gpu);
+      currentPipeline = slot;
+    },
+
+    applyBindings(bind: Bindings) {
+      if (!passEncoder) throw new Error("No active pass");
+      for (let i = 0; i < bind.vertexBuffers.length; i++) {
+        const buf = buffers.get(bind.vertexBuffers[i].id);
+        if (!buf) throw new Error(`Invalid vertex buffer at index ${i}`);
+        passEncoder.setVertexBuffer(i, buf.gpu);
+      }
+      if (bind.indexBuffer) {
+        const buf = buffers.get(bind.indexBuffer.id);
+        if (!buf) throw new Error("Invalid index buffer");
+        const fmt = currentPipeline?.indexType === IndexType.UINT32 ? "uint32" : "uint16";
+        passEncoder.setIndexBuffer(buf.gpu, fmt);
+      }
+    },
+
+    applyUniforms(data: ArrayBufferView) {
+      if (!passEncoder) throw new Error("No active pass");
+      const ub = ensureUniformBuffer();
+
+      // Align to 256 bytes (WebGPU requirement for dynamic offsets)
+      const alignedOffset = Math.ceil(uniformOffset / 256) * 256;
+      device.queue.writeBuffer(ub, alignedOffset, data.buffer, data.byteOffset, data.byteLength);
+
+      uniformBindGroup = device.createBindGroup({
+        layout: currentPipeline!.gpu.getBindGroupLayout(0),
+        entries: [{ binding: 0, resource: { buffer: ub, size: Math.max(data.byteLength, 256) } }],
+      });
+      passEncoder.setBindGroup(0, uniformBindGroup, [alignedOffset]);
+
+      uniformOffset = alignedOffset + Math.max(data.byteLength, 256);
+    },
+
+    draw(baseElement: number, numElements: number, numInstances = 1) {
+      if (!passEncoder) throw new Error("No active pass");
+      if (currentPipeline?.indexType !== IndexType.NONE) {
+        passEncoder.drawIndexed(numElements, numInstances, baseElement);
+      } else {
+        passEncoder.draw(numElements, numInstances, baseElement);
+      }
+    },
+
+    endPass() {
+      if (passEncoder) {
+        passEncoder.end();
+        passEncoder = null;
+      }
+    },
+
+    commit() {
+      if (encoder) {
+        device.queue.submit([encoder.finish()]);
+        encoder = null;
+      }
+      currentPipeline = null;
+      uniformBindGroup = null;
+
+      const now = performance.now();
+      frameTime = (now - lastFrameTime) / 1000;
+      lastFrameTime = now;
+      _frameCount++;
+    },
+  };
+
+  return gfx;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export { run } from "./app.js";
+export { createGfx } from "./gfx.js";
+export * from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,245 @@
+// Resource handles — thin wrappers for type safety
+export interface SgBuffer { readonly _brand: "SgBuffer"; readonly id: number }
+export interface SgImage { readonly _brand: "SgImage"; readonly id: number }
+export interface SgSampler { readonly _brand: "SgSampler"; readonly id: number }
+export interface SgShader { readonly _brand: "SgShader"; readonly id: number }
+export interface SgPipeline { readonly _brand: "SgPipeline"; readonly id: number }
+
+export type Handle = SgBuffer | SgImage | SgSampler | SgShader | SgPipeline;
+
+// Enums matching Sokol conventions
+
+export enum VertexFormat {
+  FLOAT2 = "float32x2",
+  FLOAT3 = "float32x3",
+  FLOAT4 = "float32x4",
+  UBYTE4N = "unorm8x4",
+}
+
+export enum IndexType {
+  NONE = 0,
+  UINT16 = 1,
+  UINT32 = 2,
+}
+
+export enum PrimitiveType {
+  TRIANGLES = "triangle-list",
+  TRIANGLE_STRIP = "triangle-strip",
+  LINES = "line-list",
+  LINE_STRIP = "line-strip",
+  POINTS = "point-list",
+}
+
+export enum CullMode {
+  NONE = "none",
+  FRONT = "front",
+  BACK = "back",
+}
+
+export enum CompareFunc {
+  NEVER = "never",
+  LESS = "less",
+  EQUAL = "equal",
+  LESS_EQUAL = "less-equal",
+  GREATER = "greater",
+  NOT_EQUAL = "not-equal",
+  GREATER_EQUAL = "greater-equal",
+  ALWAYS = "always",
+}
+
+export enum FilterMode {
+  NEAREST = "nearest",
+  LINEAR = "linear",
+}
+
+export enum WrapMode {
+  REPEAT = "repeat",
+  CLAMP = "clamp-to-edge",
+  MIRROR = "mirror-repeat",
+}
+
+export enum PixelFormat {
+  RGBA8 = "rgba8unorm",
+  BGRA8 = "bgra8unorm",
+  DEPTH24_STENCIL8 = "depth24plus-stencil8",
+  DEPTH32F = "depth32float",
+  R8 = "r8unorm",
+  RG8 = "rg8unorm",
+  RGBA16F = "rgba16float",
+  RGBA32F = "rgba32float",
+}
+
+export enum LoadAction {
+  CLEAR = 0,
+  LOAD = 1,
+  DONTCARE = 2,
+}
+
+export enum BufferUsage {
+  IMMUTABLE = 0,
+  DYNAMIC = 1,
+  STREAM = 2,
+}
+
+// Desc structs — all fields optional, defaults applied at creation
+
+export interface BufferDesc {
+  usage?: BufferUsage;
+  data?: ArrayBufferView;
+  size?: number;
+  label?: string;
+}
+
+export interface ImageDesc {
+  width: number;
+  height: number;
+  format?: PixelFormat;
+  data?: ArrayBufferView;
+  renderTarget?: boolean;
+  label?: string;
+}
+
+export interface SamplerDesc {
+  minFilter?: FilterMode;
+  magFilter?: FilterMode;
+  mipmapFilter?: FilterMode;
+  wrapU?: WrapMode;
+  wrapV?: WrapMode;
+  compare?: CompareFunc;
+  label?: string;
+}
+
+export interface VertexAttrDesc {
+  format: VertexFormat;
+  shaderLocation: number;
+  offset?: number;
+  bufferIndex?: number;
+}
+
+export interface VertexBufferLayoutDesc {
+  stride: number;
+  stepMode?: GPUVertexStepMode;
+}
+
+export interface ShaderDesc {
+  vertexSource: string;
+  fragmentSource: string;
+  label?: string;
+}
+
+export interface ColorTargetDesc {
+  format?: PixelFormat;
+  blendEnabled?: boolean;
+}
+
+export interface DepthStencilDesc {
+  format?: PixelFormat;
+  depthWrite?: boolean;
+  depthCompare?: CompareFunc;
+}
+
+export interface PipelineDesc {
+  shader: SgShader;
+  layout: {
+    buffers: VertexBufferLayoutDesc[];
+    attrs: VertexAttrDesc[];
+  };
+  primitive?: PrimitiveType;
+  cullMode?: CullMode;
+  indexType?: IndexType;
+  colors?: ColorTargetDesc[];
+  depth?: DepthStencilDesc;
+  label?: string;
+}
+
+export interface Bindings {
+  vertexBuffers: SgBuffer[];
+  indexBuffer?: SgBuffer;
+  images?: SgImage[];
+  samplers?: SgSampler[];
+}
+
+export interface ColorAttachment {
+  action?: LoadAction;
+  color?: [number, number, number, number];
+}
+
+export interface PassDesc {
+  colorAttachments?: ColorAttachment[];
+  depthAttachment?: {
+    action?: LoadAction;
+    value?: number;
+  };
+  // If omitted, renders to the swapchain
+  offscreen?: {
+    colorImages: SgImage[];
+    depthImage?: SgImage;
+  };
+}
+
+export interface AppDesc {
+  canvas: HTMLCanvasElement | string;
+  init: (gfx: Gfx) => void | Promise<void>;
+  frame: (gfx: Gfx) => void;
+  cleanup?: (gfx: Gfx) => void;
+  event?: (ev: AppEvent, gfx: Gfx) => void;
+  pixelRatio?: number;
+}
+
+export interface Gfx {
+  makeBuffer(desc: BufferDesc): SgBuffer;
+  makeImage(desc: ImageDesc): SgImage;
+  makeSampler(desc: SamplerDesc): SgSampler;
+  makeShader(desc: ShaderDesc): SgShader;
+  makePipeline(desc: PipelineDesc): SgPipeline;
+
+  destroyBuffer(buf: SgBuffer): void;
+  destroyImage(img: SgImage): void;
+  destroySampler(smp: SgSampler): void;
+  destroyShader(shd: SgShader): void;
+  destroyPipeline(pip: SgPipeline): void;
+
+  updateBuffer(buf: SgBuffer, data: ArrayBufferView): void;
+
+  beginPass(desc?: PassDesc): void;
+  applyPipeline(pip: SgPipeline): void;
+  applyBindings(bind: Bindings): void;
+  applyUniforms(data: ArrayBufferView): void;
+  draw(baseElement: number, numElements: number, numInstances?: number): void;
+  endPass(): void;
+  commit(): void;
+
+  readonly canvas: HTMLCanvasElement;
+  readonly device: GPUDevice;
+  readonly width: number;
+  readonly height: number;
+  readonly dt: number;
+  readonly frameCount: number;
+}
+
+export interface AppEvent {
+  type: AppEventType;
+  key?: string;
+  code?: string;
+  mouseX?: number;
+  mouseY?: number;
+  mouseButton?: number;
+  deltaX?: number;
+  deltaY?: number;
+  width?: number;
+  height?: number;
+  touches?: { id: number; x: number; y: number }[];
+}
+
+export enum AppEventType {
+  KEY_DOWN = "keydown",
+  KEY_UP = "keyup",
+  MOUSE_DOWN = "mousedown",
+  MOUSE_UP = "mouseup",
+  MOUSE_MOVE = "mousemove",
+  MOUSE_WHEEL = "wheel",
+  RESIZE = "resize",
+  TOUCH_START = "touchstart",
+  TOUCH_MOVE = "touchmove",
+  TOUCH_END = "touchend",
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
+    "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "types": ["@webgpu/types"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["@webgpu/types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds the core `sokol_gfx` equivalent: typed resource handles, buffer/image/sampler/shader/pipeline creation, render pass management, uniform binding with dynamic offsets, and draw call dispatch
- Adds the `sokol_app` equivalent: async WebGPU initialization, requestAnimationFrame loop, input events (keyboard, mouse, touch, resize), high-DPI handling, and cleanup
- Defines the full type system: enums for vertex formats, pixel formats, blend/depth/cull modes, and descriptor interfaces for all resources

## Files

| File | Purpose |
|------|---------|
| `src/types.ts` | All resource handles, enums, descriptor interfaces, `Gfx` and `AppEvent` types |
| `src/gfx.ts` | `createGfx()` — WebGPU resource management and rendering implementation |
| `src/app.ts` | `run()` — app lifecycle, WebGPU init, input events, frame loop |
| `src/index.ts` | Public API re-exports |
| `tsconfig.json` | TypeScript config (strict, ESNext, bundler resolution) |

## Test plan

- [ ] `npx tsc --noEmit` passes with no type errors
- [ ] Review all WebGPU API usage for correctness
- [ ] Verify resource handle branding prevents cross-type misuse
- [ ] Confirm descriptor defaults match Sokol conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)