### PR TITLE
Add shader compilation error handling and combined WGSL support

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -29,8 +29,8 @@ interface SamplerSlot {
 interface ShaderSlot {
   vertexModule: GPUShaderModule;
   fragmentModule: GPUShaderModule;
-  vertexSource: string;
-  fragmentSource: string;
+  vertexEntry: string;
+  fragmentEntry: string;
 }
 
 interface PipelineSlot {
@@ -146,11 +146,38 @@ export function createGfx(
       return h;
     },
 
-    makeShader(desc: ShaderDesc): SgShader {
+    async makeShader(desc: ShaderDesc): Promise<SgShader> {
       const h = handle<SgShader>("SgShader");
-      const vertexModule = device.createShaderModule({ code: desc.vertexSource, label: desc.label ? `${desc.label}_vs` : undefined });
-      const fragmentModule = device.createShaderModule({ code: desc.fragmentSource, label: desc.label ? `${desc.label}_fs` : undefined });
-      shaders.set(h.id, { vertexModule, fragmentModule, vertexSource: desc.vertexSource, fragmentSource: desc.fragmentSource });
+      const combinedSource = desc.source;
+      const vertexModule = device.createShaderModule({
+        code: combinedSource ?? desc.vertexSource!,
+        label: desc.label ? `${desc.label}_vs` : undefined,
+      });
+      const fragmentModule = combinedSource
+        ? vertexModule
+        : device.createShaderModule({
+            code: desc.fragmentSource!,
+            label: desc.label ? `${desc.label}_fs` : undefined,
+          });
+
+      async function checkCompilation(mod: GPUShaderModule, stage: string) {
+        const info = await mod.getCompilationInfo();
+        for (const msg of info.messages) {
+          const loc = `${msg.lineNum}:${msg.linePos}`;
+          if (msg.type === "error") throw new Error(`[${stage} shader] ${loc}: ${msg.message}`);
+          if (msg.type === "warning") console.warn(`[${stage} shader] ${loc}: ${msg.message}`);
+        }
+      }
+
+      await Promise.all([
+        checkCompilation(vertexModule, "vertex"),
+        // Only check fragment separately when it's a different module
+        ...(fragmentModule !== vertexModule ? [checkCompilation(fragmentModule, "fragment")] : []),
+      ]);
+
+      const vertexEntry = desc.vertexEntry ?? "vs_main";
+      const fragmentEntry = desc.fragmentEntry ?? "fs_main";
+      shaders.set(h.id, { vertexModule, fragmentModule, vertexEntry, fragmentEntry });
       return h;
     },
 
@@ -201,12 +228,12 @@ export function createGfx(
         layout: pipelineLayout,
         vertex: {
           module: shd.vertexModule,
-          entryPoint: "vs_main",
+          entryPoint: shd.vertexEntry,
           buffers: vertexBuffers,
         },
         fragment: {
           module: shd.fragmentModule,
-          entryPoint: "fs_main",
+          entryPoint: shd.fragmentEntry,
           targets: colorTargets,
         },
         primitive: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,8 +122,11 @@ export interface VertexBufferLayoutDesc {
 }
 
 export interface ShaderDesc {
-  vertexSource: string;
-  fragmentSource: string;
+  source?: string;           // combined VS+FS in one module (used for both stages)
+  vertexSource?: string;     // used when source is absent
+  fragmentSource?: string;   // used when source is absent
+  vertexEntry?: string;      // default: "vs_main"
+  fragmentEntry?: string;    // default: "fs_main"
   label?: string;
 }
 
@@ -190,7 +193,7 @@ export interface Gfx {
   makeBuffer(desc: BufferDesc): SgBuffer;
   makeImage(desc: ImageDesc): SgImage;
   makeSampler(desc: SamplerDesc): SgSampler;
-  makeShader(desc: ShaderDesc): SgShader;
+  makeShader(desc: ShaderDesc): Promise<SgShader>;
   makePipeline(desc: PipelineDesc): SgPipeline;
 
   destroyBuffer(buf: SgBuffer): void;


### PR DESCRIPTION
Closes #5

## Changes

- **`makeShader` is now async** — awaits `getCompilationInfo()` on both shader modules before storing them. Throws a descriptive `Error` (with stage name, line, and column) on any `"error"` message; calls `console.warn` for `"warning"` messages.
- **Combined WGSL source** — `ShaderDesc` gains an optional `source` field. When provided, a single `GPUShaderModule` is created and reused for both vertex and fragment stages (compiled once, checked once).
- **Custom entry points** — `ShaderDesc` gains `vertexEntry` (default `"vs_main"`) and `fragmentEntry` (default `"fs_main"`). These are stored in `ShaderSlot` and threaded through `makePipeline` instead of the previous hardcoded strings.
- **`Gfx` interface updated** — `makeShader` signature is now `Promise<SgShader>`.

## Files changed

- `src/types.ts` — `ShaderDesc` fields updated; `Gfx.makeShader` return type changed
- `src/gfx.ts` — `ShaderSlot` fields updated; `makeShader` rewritten as async; `makePipeline` uses stored entry points