### PR TITLE
Support multiple app instances with per-instance state

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,23 +12,26 @@ export async function run(desc: AppDesc): Promise<() => void> {
     throw new Error("WebGPU is not supported in this browser");
   }
 
-  const adapterOptions: GPURequestAdapterOptions = {};
-  if (desc.powerPreference !== undefined) {
-    adapterOptions.powerPreference = desc.powerPreference;
-  }
-  const adapter = await navigator.gpu.requestAdapter(adapterOptions);
-  if (!adapter) throw new Error("Failed to get GPU adapter");
+  const callerDevice = desc.device;
+  const device = callerDevice ?? await (async () => {
+    const adapterOptions: GPURequestAdapterOptions = {};
+    if (desc.powerPreference !== undefined) {
+      adapterOptions.powerPreference = desc.powerPreference;
+    }
+    const adapter = await navigator.gpu.requestAdapter(adapterOptions);
+    if (!adapter) throw new Error("Failed to get GPU adapter");
 
-  const reqFeatures: GPUFeatureName[] = desc.requiredFeatures ?? [];
-  const unsupported = reqFeatures.filter(f => !adapter.features.has(f));
-  if (unsupported.length > 0) {
-    throw new Error(`GPU adapter does not support required features: ${unsupported.join(", ")}`);
-  }
+    const reqFeatures: GPUFeatureName[] = desc.requiredFeatures ?? [];
+    const unsupported = reqFeatures.filter(f => !adapter.features.has(f));
+    if (unsupported.length > 0) {
+      throw new Error(`GPU adapter does not support required features: ${unsupported.join(", ")}`);
+    }
 
-  const device = await adapter.requestDevice({
-    requiredFeatures: reqFeatures,
-    requiredLimits: desc.requiredLimits,
-  });
+    return adapter.requestDevice({
+      requiredFeatures: reqFeatures,
+      requiredLimits: desc.requiredLimits,
+    });
+  })();
   const context = canvas.getContext("webgpu")!;
   const format = navigator.gpu.getPreferredCanvasFormat();
 
@@ -120,6 +123,6 @@ export async function run(desc: AppDesc): Promise<() => void> {
       target.removeEventListener(type, handler);
     }
     desc.cleanup?.(gfx);
-    device.destroy();
+    if (!callerDevice) device.destroy();
   };
 }

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -6,11 +6,6 @@ import {
   FilterMode, WrapMode,
 } from "./types.js";
 
-let nextId = 1;
-function handle<T extends { readonly _brand: string; readonly id: number }>(brand: string): T {
-  return { _brand: brand, id: nextId++ } as unknown as T;
-}
-
 interface BufferSlot {
   gpu: GPUBuffer;
   desc: BufferDesc;
@@ -45,6 +40,11 @@ export function createGfx(
   context: GPUCanvasContext,
   format: GPUTextureFormat,
 ): Gfx {
+  let nextId = 1;
+  function handle<T extends { readonly _brand: string; readonly id: number }>(brand: string): T {
+    return { _brand: brand, id: nextId++ } as unknown as T;
+  }
+
   const buffers = new Map<number, BufferSlot>();
   const images = new Map<number, ImageSlot>();
   const samplers = new Map<number, SamplerSlot>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,7 @@ export interface PassDesc {
 
 export interface AppDesc {
   canvas: HTMLCanvasElement | string;
+  device?: GPUDevice;
   init: (gfx: Gfx) => void | Promise<void>;
   frame: (gfx: Gfx) => void;
   cleanup?: (gfx: Gfx) => void;


### PR DESCRIPTION
Closes #15

## Changes

- **`src/gfx.ts`**: Moved `nextId` counter and `handle()` helper inside `createGfx()` closure. Each instance now counts independently from 1, eliminating the shared mutable module-level state.

- **`src/types.ts`**: Added `device?: GPUDevice` field to `AppDesc`. Callers can supply a pre-created device to share it across multiple `run()` instances.

- **`src/app.ts`**: When `desc.device` is provided, skip adapter/device creation. When cleaning up, only call `device.destroy()` if `run()` created the device — caller-supplied devices are not destroyed (caller owns lifetime).

## Notes on event isolation

`keydown`/`keyup` listeners are bound to `window` but are tracked in a per-closure `eventMap` array. Cleanup correctly removes only that instance's handlers, leaving other instances unaffected. No code change required.