### PR TITLE
Add dynamic shader recompilation with error handling

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1,7 +1,7 @@
 import {
   type SgBuffer, type SgImage, type SgSampler, type SgShader, type SgPipeline,
   type BufferDesc, type ImageDesc, type SamplerDesc, type ShaderDesc, type PipelineDesc,
-  type Bindings, type PassDesc, type Gfx, type DrawStats,
+  type Bindings, type PassDesc, type Gfx, type DrawStats, type ShaderRecompileResult,
   BufferUsage, IndexType, LoadAction, StoreAction, PixelFormat, PrimitiveType, CullMode, CompareFunc,
   FilterMode, WrapMode,
 } from "./types.js";
@@ -31,6 +31,8 @@ interface ShaderSlot {
   fragmentModule: GPUShaderModule;
   vertexEntry: string;
   fragmentEntry: string;
+  vertexSource: string;
+  fragmentSource: string;
 }
 
 interface PipelineSlot {
@@ -193,7 +195,9 @@ export function createGfx(
 
       const vertexEntry = desc.vertexEntry ?? "vs_main";
       const fragmentEntry = desc.fragmentEntry ?? "fs_main";
-      shaders.set(h.id, { vertexModule, fragmentModule, vertexEntry, fragmentEntry });
+      const vertexSource = combinedSource ?? desc.vertexSource!;
+      const fragmentSource = combinedSource ?? desc.fragmentSource ?? vertexSource;
+      shaders.set(h.id, { vertexModule, fragmentModule, vertexEntry, fragmentEntry, vertexSource, fragmentSource });
       return h;
     },
 
@@ -270,6 +274,67 @@ export function createGfx(
 
       pipelines.set(h.id, { gpu: gpuPipeline, desc, indexType: desc.indexType ?? IndexType.NONE });
       return h;
+    },
+
+    async recompileShader(
+      shd: SgShader,
+      sources: { vertexSource?: string; fragmentSource?: string },
+      callback?: (result: ShaderRecompileResult) => void,
+    ): Promise<ShaderRecompileResult> {
+      const slot = shaders.get(shd.id);
+      if (!slot) {
+        const result: ShaderRecompileResult = { ok: false, vertexError: "Invalid shader handle" };
+        callback?.(result);
+        return result;
+      }
+
+      const nextVertex = sources.vertexSource ?? slot.vertexSource;
+      const nextFragment = sources.fragmentSource ?? slot.fragmentSource;
+
+      // Diff-based early exit — no work if source is unchanged
+      if (nextVertex === slot.vertexSource && nextFragment === slot.fragmentSource) {
+        const result: ShaderRecompileResult = { ok: true, shader: shd };
+        callback?.(result);
+        return result;
+      }
+
+      // Compile new modules — createShaderModule never throws; errors surface via getCompilationInfo()
+      const newVert = device.createShaderModule({ code: nextVertex, label: `${shd.id}_vs_hot` });
+      const newFrag = device.createShaderModule({ code: nextFragment, label: `${shd.id}_fs_hot` });
+
+      const [vertInfo, fragInfo] = await Promise.all([
+        newVert.getCompilationInfo(),
+        newFrag.getCompilationInfo(),
+      ]);
+
+      const vertErrors = vertInfo.messages
+        .filter(m => m.type === "error")
+        .map(m => m.message)
+        .join("\n");
+      const fragErrors = fragInfo.messages
+        .filter(m => m.type === "error")
+        .map(m => m.message)
+        .join("\n");
+
+      if (vertErrors || fragErrors) {
+        const result: ShaderRecompileResult = {
+          ok: false,
+          vertexError: vertErrors || undefined,
+          fragmentError: fragErrors || undefined,
+        };
+        callback?.(result);
+        return result;
+      }
+
+      // Atomically commit new modules and updated source to the slot
+      slot.vertexModule = newVert;
+      slot.fragmentModule = newFrag;
+      slot.vertexSource = nextVertex;
+      slot.fragmentSource = nextFragment;
+
+      const result: ShaderRecompileResult = { ok: true, shader: shd };
+      callback?.(result);
+      return result;
     },
 
     destroyBuffer(buf: SgBuffer) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,12 +205,21 @@ export interface AppDesc {
   dpiIndependentCoords?: boolean; // default false; when true all event coords are in CSS pixels
 }
 
+export type ShaderRecompileResult =
+  | { ok: true; shader: SgShader }
+  | { ok: false; vertexError?: string; fragmentError?: string };
+
 export interface Gfx {
   makeBuffer(desc: BufferDesc): SgBuffer;
   makeImage(desc: ImageDesc): SgImage;
   makeSampler(desc: SamplerDesc): SgSampler;
   makeShader(desc: ShaderDesc): Promise<SgShader>;
   makePipeline(desc: PipelineDesc): SgPipeline;
+  recompileShader(
+    shd: SgShader,
+    sources: { vertexSource?: string; fragmentSource?: string },
+    callback?: (result: ShaderRecompileResult) => void,
+  ): Promise<ShaderRecompileResult>;
 
   destroyBuffer(buf: SgBuffer): void;
   destroyImage(img: SgImage): void;


### PR DESCRIPTION
Closes #16

## Summary

- Adds `ShaderRecompileResult` discriminated union type to `src/types.ts` (`{ ok: true; shader }` or `{ ok: false; vertexError?; fragmentError? }`)
- Extends the `Gfx` interface with `recompileShader(shd, sources, callback?): Promise<ShaderRecompileResult>`
- Implements the method in `src/gfx.ts` inside `createGfx`:
  - **Diff-based skip**: returns `{ ok: true }` immediately if both sources are unchanged, avoiding unnecessary GPU work
  - **Safe error capture**: uses `getCompilationInfo()` (not exceptions) to surface vertex/fragment compile errors; bad WGSL returns `{ ok: false }` without touching the slot or crashing the app
  - **Atomic commit**: only replaces `ShaderSlot` modules and source strings after both modules pass compilation info checks
  - **Optional callback**: invoked with the result for sync-style callers alongside the returned Promise
- Pipeline rebuilding for dependent `PipelineSlot` entries is intentionally out of scope — tracked in issue #18

## Test plan

- [ ] Diff guard: call `recompileShader` twice with identical source; second call skips `createShaderModule`
- [ ] Error isolation: pass broken WGSL; assert `result.ok === false`, error strings non-empty, app continues rendering
- [ ] Success path: valid new WGSL updates `ShaderSlot` modules and source strings
- [ ] Invalid handle: missing shader id returns `{ ok: false, vertexError: "Invalid shader handle" }`
- [ ] Callback: invoked correctly on both success and failure paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)