### PR TITLE
Add uniform buffer overflow detection and ring-buffered allocation

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -151,27 +151,51 @@ export function createGfx(
   let lastFrameTime = 0;
   let _frameCount = 0;
   let uniformOffset = 0;
-  let uniformBuffer: GPUBuffer | null = null;
-  let uniformBindGroup: GPUBindGroup | null = null;
   let boundVertexBuffers: BufferSlot[] = [];
   let boundIndexBuffer: BufferSlot | null = null;
   let _frameStats: DrawStats = { drawCalls: 0, totalElements: 0, indirectDrawCalls: 0 };
 
-  const UNIFORM_BUFFER_SIZE = 65536; // 64KB uniform staging
+  const UNIFORM_BUFFER_SIZE = 65536; // 64KB uniform staging per ring slot
   if (UNIFORM_BUFFER_SIZE > device.limits.maxUniformBufferBindingSize) {
     throw new Error(
       `UNIFORM_BUFFER_SIZE (${UNIFORM_BUFFER_SIZE}) exceeds device limit maxUniformBufferBindingSize (${device.limits.maxUniformBufferBindingSize})`
     );
   }
+  const NUM_FRAMES_IN_FLIGHT = 2;
+  let uniformFrameIndex = 0;
 
-  function ensureUniformBuffer() {
-    if (!uniformBuffer) {
-      uniformBuffer = device.createBuffer({
-        size: UNIFORM_BUFFER_SIZE,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-      });
-    }
-    return uniformBuffer;
+  // Shared bind group layout for the uniform ring buffers (group 0, binding 0, dynamic offset)
+  const uniformBindGroupLayout = device.createBindGroupLayout({
+    entries: [{
+      binding: 0,
+      visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+      buffer: { type: "uniform", hasDynamicOffset: true },
+    }],
+  });
+
+  // Allocate NUM_FRAMES_IN_FLIGHT uniform buffers and one bind group per slot up front
+  const uniformBuffers: GPUBuffer[] = [];
+  const uniformBindGroups: GPUBindGroup[] = [];
+  for (let i = 0; i < NUM_FRAMES_IN_FLIGHT; i++) {
+    const buf = device.createBuffer({
+      size: UNIFORM_BUFFER_SIZE,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      label: `uniform_ring_${i}`,
+    });
+    uniformBuffers.push(buf);
+    uniformBindGroups.push(device.createBindGroup({
+      layout: uniformBindGroupLayout,
+      entries: [{ binding: 0, resource: { buffer: buf, size: 256 } }],
+      label: `uniform_bind_group_${i}`,
+    }));
+  }
+
+  function currentUniformBuffer() {
+    return uniformBuffers[uniformFrameIndex];
+  }
+
+  function currentUniformBindGroup() {
+    return uniformBindGroups[uniformFrameIndex];
   }
 
   function gpuBufferUsage(usage: BufferUsage | undefined): number {
@@ -369,14 +393,8 @@ export function createGfx(
 
       const bindGroupLayouts: GPUBindGroupLayout[] = [];
 
-      // Group 0: uniform buffer (always present)
-      bindGroupLayouts.push(device.createBindGroupLayout({
-        entries: [{
-          binding: 0,
-          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
-          buffer: { type: "uniform", hasDynamicOffset: true },
-        }],
-      }));
+      // Group 0: uniform buffer (always present) — reuse the shared layout
+      bindGroupLayouts.push(uniformBindGroupLayout);
 
       // Group 1: textures + samplers (if any)
       // Texture bindings occupy locations 0..images-1;
@@ -719,19 +737,26 @@ export function createGfx(
 
     applyUniforms(data: ArrayBufferView) {
       if (!passEncoder) throw new Error("No active pass");
-      const ub = ensureUniformBuffer();
 
       // Align to 256 bytes (WebGPU requirement for dynamic offsets)
       const alignedOffset = Math.ceil(uniformOffset / 256) * 256;
+      const slotSize = Math.max(data.byteLength, 256);
+
+      // Overflow detection: ensure we don't write past the end of the ring slot
+      if (alignedOffset + slotSize > UNIFORM_BUFFER_SIZE) {
+        throw new Error(
+          `Uniform buffer overflow: offset ${alignedOffset} + ${slotSize} exceeds UNIFORM_BUFFER_SIZE (${UNIFORM_BUFFER_SIZE}). ` +
+          `Too many applyUniforms calls in a single pass.`
+        );
+      }
+
+      const ub = currentUniformBuffer();
       device.queue.writeBuffer(ub, alignedOffset, data.buffer, data.byteOffset, data.byteLength);
 
-      uniformBindGroup = device.createBindGroup({
-        layout: currentPipeline!.gpu.getBindGroupLayout(0),
-        entries: [{ binding: 0, resource: { buffer: ub, size: Math.max(data.byteLength, 256) } }],
-      });
-      passEncoder.setBindGroup(0, uniformBindGroup, [alignedOffset]);
+      // Use the pre-created bind group for this ring slot; supply the dynamic offset
+      passEncoder.setBindGroup(0, currentUniformBindGroup(), [alignedOffset]);
 
-      uniformOffset = alignedOffset + Math.max(data.byteLength, 256);
+      uniformOffset = alignedOffset + slotSize;
     },
 
     draw(baseElement: number, numElements?: number, numInstances = 1) {
@@ -811,8 +836,10 @@ export function createGfx(
         encoder = null;
       }
       currentPipeline = null;
-      uniformBindGroup = null;
       uniformOffset = 0;
+
+      // Advance the ring buffer index so the next frame writes to a different slot
+      uniformFrameIndex = (uniformFrameIndex + 1) % NUM_FRAMES_IN_FLIGHT;
 
       const now = performance.now();
       frameTime = (now - lastFrameTime) / 1000;

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -6,6 +6,9 @@ import {
   FilterMode, WrapMode,
 } from "./types.js";
 
+/** Number of uniform ring-buffer slots to prevent CPU/GPU aliasing. */
+export const NUM_FRAMES_IN_FLIGHT = 2;
+
 // ---------------------------------------------------------------------------
 // Generation-counted handle encoding (matches Sokol's _sg_slot_t strategy)
 // ---------------------------------------------------------------------------
@@ -161,7 +164,6 @@ export function createGfx(
       `UNIFORM_BUFFER_SIZE (${UNIFORM_BUFFER_SIZE}) exceeds device limit maxUniformBufferBindingSize (${device.limits.maxUniformBufferBindingSize})`
     );
   }
-  const NUM_FRAMES_IN_FLIGHT = 2;
   let uniformFrameIndex = 0;
 
   // Shared bind group layout for the uniform ring buffers (group 0, binding 0, dynamic offset)
@@ -185,7 +187,7 @@ export function createGfx(
     uniformBuffers.push(buf);
     uniformBindGroups.push(device.createBindGroup({
       layout: uniformBindGroupLayout,
-      entries: [{ binding: 0, resource: { buffer: buf, size: 256 } }],
+      entries: [{ binding: 0, resource: { buffer: buf, size: UNIFORM_BUFFER_SIZE } }],
       label: `uniform_bind_group_${i}`,
     }));
   }


### PR DESCRIPTION
## Summary

- **Overflow detection**: `applyUniforms` now checks `alignedOffset + slotSize > UNIFORM_BUFFER_SIZE` before calling `writeBuffer` and throws a descriptive error, preventing silent GPU validation errors when a pass issues too many uniform updates.
- **Ring-buffered allocation**: `createGfx` allocates `NUM_FRAMES_IN_FLIGHT` (2) `GPUBuffer`s up front. `commit()` advances `uniformFrameIndex` modulo `NUM_FRAMES_IN_FLIGHT`, ensuring the CPU never writes into a buffer the GPU is still reading from a prior frame.
- **Reduced bind group overhead**: One `GPUBindGroup` is pre-created per ring slot at init time. `applyUniforms` now calls `passEncoder.setBindGroup` with the cached group and a dynamic offset — eliminating the `device.createBindGroup` allocation that previously occurred on every draw call. `makePipeline` also reuses the shared `uniformBindGroupLayout` instead of creating a new layout per pipeline.

## Test plan

- [ ] Overflow detection — call `applyUniforms` in a loop with 256-byte payloads until 64 KB is exhausted; assert the 257th call throws with a clear message.
- [ ] Ring-buffer correctness — render two frames back-to-back with different uniform values; assert frame N+1 does not corrupt frame N's result (GPU readback via `copyTextureToBuffer`).
- [ ] Bind group cache hit rate — instrument `device.createBindGroup` with a spy; render 100 frames with a single `applyUniforms` call each; assert `createBindGroup` is called at most `NUM_FRAMES_IN_FLIGHT` times total.
- [ ] Regression — run existing triangle/quad samples and assert uniform data is delivered correctly after all changes.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)