### PR TITLE
Support separate vertex/fragment shader URLs in fetchShader

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -236,21 +236,77 @@ export function createSfetch(desc?: FetchSetupDesc): SfetchContext {
     },
 
     fetchShader(gfx: Gfx, req: FetchShaderRequest): void {
-      ctx.fetch<string>({
-        url: req.url,
-        type: "text",
-        signal: req.signal,
-        onProgress: req.onProgress,
-        onError: req.onError,
-        onDone(source, url) {
-          const shader = gfx.makeShader({
-            vertexSource: source,
-            fragmentSource: source,
-            label: req.label,
-          });
-          req.onDone(shader, url);
-        },
-      });
+      if (req.vertexUrl && req.fragmentUrl) {
+        // Separate vertex/fragment shader files — fetch in parallel.
+        let vertexSource: string | undefined;
+        let fragmentSource: string | undefined;
+        let completed = 0;
+        let errored = false;
+
+        const finish = async () => {
+          if (++completed < 2 || errored) return;
+          try {
+            const shader = await gfx.makeShader({
+              vertexSource: vertexSource!,
+              fragmentSource: fragmentSource!,
+              label: req.label,
+            });
+            req.onDone(shader, `${req.vertexUrl}+${req.fragmentUrl}`);
+          } catch (err) {
+            onError(err instanceof Error ? err : new Error(String(err)), `${req.vertexUrl}+${req.fragmentUrl}`);
+          }
+        };
+
+        const onError = (err: Error, url: string) => {
+          if (errored) return;
+          errored = true;
+          if (req.onError) req.onError(err, url);
+        };
+
+        ctx.fetch<string>({
+          url: req.vertexUrl,
+          type: "text",
+          signal: req.signal,
+          onProgress: req.onProgress,
+          onError,
+          onDone(source) {
+            vertexSource = source;
+            finish();
+          },
+        });
+
+        ctx.fetch<string>({
+          url: req.fragmentUrl,
+          type: "text",
+          signal: req.signal,
+          onError,
+          onDone(source) {
+            fragmentSource = source;
+            finish();
+          },
+        });
+      } else {
+        // Single combined WGSL file.
+        ctx.fetch<string>({
+          url: req.url!,
+          type: "text",
+          signal: req.signal,
+          onProgress: req.onProgress,
+          onError: req.onError,
+          async onDone(source, url) {
+            try {
+              const shader = await gfx.makeShader({
+                vertexSource: source,
+                fragmentSource: source,
+                label: req.label,
+              });
+              req.onDone(shader, url);
+            } catch (err) {
+              if (req.onError) req.onError(err instanceof Error ? err : new Error(String(err)), url);
+            }
+          },
+        });
+      }
     },
 
     batch(requests: FetchRequest<unknown>[], onAllDone: () => void): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,14 +344,30 @@ export interface FetchImageRequest {
   label?: string;
 }
 
-export interface FetchShaderRequest {
-  url: string;
+/** Base fields shared by both single-URL and split-URL shader requests. */
+interface FetchShaderRequestBase {
   signal?: AbortSignal;
   onProgress?: (p: FetchProgress) => void;
   onDone: (shader: SgShader, url: string) => void;
   onError?: (err: Error, url: string) => void;
   label?: string;
 }
+
+/** Single combined WGSL file (used for both vertex and fragment stages). */
+export interface FetchShaderSingleRequest extends FetchShaderRequestBase {
+  url: string;
+  vertexUrl?: undefined;
+  fragmentUrl?: undefined;
+}
+
+/** Separate vertex and fragment WGSL files, fetched in parallel. */
+export interface FetchShaderSplitRequest extends FetchShaderRequestBase {
+  url?: undefined;
+  vertexUrl: string;
+  fragmentUrl: string;
+}
+
+export type FetchShaderRequest = FetchShaderSingleRequest | FetchShaderSplitRequest;
 
 export interface FetchSetupDesc {
   maxConcurrent?: number;   // default 6, mirrors browser connection limits


### PR DESCRIPTION
## Summary

- Add `vertexUrl` / `fragmentUrl` fields to `FetchShaderRequest` as a discriminated union alternative to the existing single `url` field
- When both split URLs are provided, fetch vertex and fragment WGSL files in parallel via the existing sfetch queue, then pass them as separate `vertexSource`/`fragmentSource` to `gfx.makeShader()`
- Backward compatible: the existing single-URL form continues to work unchanged

## Changes

- **`src/types.ts`** — Refactored `FetchShaderRequest` into a discriminated union (`FetchShaderSingleRequest | FetchShaderSplitRequest`) with a shared base interface
- **`src/fetch.ts`** — Extended `fetchShader()` to detect split URLs and issue two parallel fetches, combining the results before calling `makeShader()`; also fixed both paths to properly `await` the async `makeShader()` call

## Test plan

- [ ] Verify single-URL `fetchShader` still works (backward compat)
- [ ] Verify `{ vertexUrl, fragmentUrl }` fetches both files and creates a shader with separate modules
- [ ] Verify error in either fetch reports via `onError` and does not call `onDone`
- [ ] `npx tsc --noEmit` passes cleanly

Closes #56