### PR TITLE
ci: add unit tests and e2e tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build & type-check (Node ${{ matrix.node-version }})
+    name: Build & unit tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -31,3 +31,27 @@ jobs:
 
       - name: Build (tsc)
         run: npm run build
+
+      - name: Unit tests (Vitest)
+        run: npm test
+
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: E2E tests (Playwright)
+        run: npm run test:e2e


### PR DESCRIPTION
## Summary
Add the existing Vitest unit tests and Playwright e2e tests to the CI pipeline so regressions are caught before landing on main.

## Changes
- Add `npm test` (Vitest) step to the existing build matrix job (Node 20 and 22)
- Add a separate `e2e` job that installs Playwright Chromium with dependencies and runs `npm run test:e2e` on Node 22
- Rename the build job from "Build & type-check" to "Build & unit tests" to reflect its expanded scope

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `npm test` runs in CI on push to main and PRs | PASS | Added as step in `build` job which triggers on `push: main` and `pull_request` |
| `npm run test:e2e` runs in CI on push to main and PRs | PASS | Added as separate `e2e` job with same triggers |
| CI fails if any test fails | PASS | Both steps use default shell error handling (set -e); non-zero exit fails the job |
| Playwright Chromium installed before e2e | PASS | `npx playwright install chromium --with-deps` step precedes test step |
| E2e uses existing SwiftShader/headless config | PASS | `playwright.config.ts` already checks `process.env.CI` and adds SwiftShader args; no changes needed |

## Test Plan
- The PR itself will trigger CI and run both test suites, confirming they work on GitHub Actions runners.

Closes #70