### PR TITLE
docs: remove hardcoded unit test count from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ npx vite examples/instancing      # 64 instanced triangles
 ```bash
 npm install
 npm run lint            # type-check (tsc --noEmit)
-npm test                # unit tests (vitest, 43 tests)
+npm test                # unit tests (vitest)
 npm run test:e2e        # e2e tests (playwright, 9 tests -- renders all examples in Chromium)
 npm run build           # emit to dist/
 npm run docs            # generate TypeDoc API docs


### PR DESCRIPTION
## Summary
Remove the hardcoded unit test count ("43 tests") from README.md line 95 to prevent future staleness. The actual count is 93 and will continue to grow as tests are added.

## Changes
- Removed the hardcoded test count from the `npm test` comment in the Development section, changing it from `unit tests (vitest, 43 tests)` to `unit tests (vitest)`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| README no longer hardcodes a specific test count | PASS | Verified via `git diff` -- count removed from line 95 |
| Change avoids future staleness | PASS | No number to go stale; vitest output shows the real count at runtime |

## Test Plan
- Documentation-only change; no automated tests needed
- Manual verification: the diff shows the hardcoded "43 tests" removed

Closes #80