### PR TITLE
docs: add handle-lifetime and uniform-alignment gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npx vite examples/instancing      # 64 instanced triangles
 
 ### Handle lifetime is manual
 
-`makeBuffer()`, `makeImage()`, `makeSampler()`, `makeShader()`, and `makePipeline()` each allocate a slot in a fixed-size pool (4 096 entries by default). These slots are **not** garbage-collected -- you must call the matching `destroy*()` method when a resource is no longer needed. Leaking handles eventually exhausts the pool, which throws at runtime. `shutdown()` destroys all live resources and logs warnings for any that were not explicitly released, but relying on shutdown for cleanup is not a substitute for proper lifetime management.
+`makeBuffer()`, `makeImage()`, `makeSampler()`, `makeShader()`, and `makePipeline()` each allocate a slot in a fixed-size pool (64 to 128 entries depending on resource type). These slots are **not** garbage-collected -- you must call the matching `destroy*()` method when a resource is no longer needed. Leaking handles eventually exhausts the pool, which throws at runtime. `shutdown()` destroys all live resources and logs warnings for any that were not explicitly released, but relying on shutdown for cleanup is not a substitute for proper lifetime management.
 
 ```typescript
 const buf = gfx.makeBuffer({ data: vertices });

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ npx vite examples/instancing      # 64 instanced triangles
 - **Debug text overlay** with printf-style formatting
 - **Vite HMR** -- live reload with serializable state
 
+## Gotchas
+
+### Handle lifetime is manual
+
+`makeBuffer()`, `makeImage()`, `makeSampler()`, `makeShader()`, and `makePipeline()` each allocate a slot in a fixed-size pool (4 096 entries by default). These slots are **not** garbage-collected -- you must call the matching `destroy*()` method when a resource is no longer needed. Leaking handles eventually exhausts the pool, which throws at runtime. `shutdown()` destroys all live resources and logs warnings for any that were not explicitly released, but relying on shutdown for cleanup is not a substitute for proper lifetime management.
+
+```typescript
+const buf = gfx.makeBuffer({ data: vertices });
+// ... use buf ...
+gfx.destroyBuffer(buf); // free the pool slot and GPU memory
+```
+
+### Uniform buffer 256-byte alignment
+
+Each `applyUniforms(data)` call writes into a shared 64 KB ring buffer that is reset every frame. Writes are aligned to 256-byte boundaries (the WebGPU `minUniformBufferOffsetAlignment` requirement), so every call reserves at least 256 bytes regardless of the actual data size. This means at most 256 uniform calls can fit in a single frame (`65 536 / 256 = 256`). If you exceed this budget the library will throw. Keep uniform data small and batch where possible.
+
 ## Development
 
 ```bash

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,19 +11,44 @@
 // Resource handles -- thin wrappers for type safety
 // ---------------------------------------------------------------------------
 
-/** Opaque handle to a GPU buffer resource. */
+/**
+ * Opaque handle to a GPU buffer resource.
+ *
+ * @remarks Handles are manually managed. Call {@link Gfx.destroyBuffer} when
+ * the buffer is no longer needed to free the pool slot and GPU memory.
+ */
 export interface SgBuffer { readonly _brand: "SgBuffer"; readonly id: number }
 
-/** Opaque handle to a GPU image (texture) resource. */
+/**
+ * Opaque handle to a GPU image (texture) resource.
+ *
+ * @remarks Handles are manually managed. Call {@link Gfx.destroyImage} when
+ * the image is no longer needed to free the pool slot and GPU memory.
+ */
 export interface SgImage { readonly _brand: "SgImage"; readonly id: number }
 
-/** Opaque handle to a GPU sampler resource. */
+/**
+ * Opaque handle to a GPU sampler resource.
+ *
+ * @remarks Handles are manually managed. Call {@link Gfx.destroySampler} when
+ * the sampler is no longer needed to free the pool slot.
+ */
 export interface SgSampler { readonly _brand: "SgSampler"; readonly id: number }
 
-/** Opaque handle to a compiled shader resource. */
+/**
+ * Opaque handle to a compiled shader resource.
+ *
+ * @remarks Handles are manually managed. Call {@link Gfx.destroyShader} when
+ * the shader is no longer needed to free the pool slot.
+ */
 export interface SgShader { readonly _brand: "SgShader"; readonly id: number }
 
-/** Opaque handle to a render pipeline resource. */
+/**
+ * Opaque handle to a render pipeline resource.
+ *
+ * @remarks Handles are manually managed. Call {@link Gfx.destroyPipeline} when
+ * the pipeline is no longer needed to free the pool slot.
+ */
 export interface SgPipeline { readonly _brand: "SgPipeline"; readonly id: number }
 
 /** Union of all GPU resource handle types. */
@@ -580,6 +605,7 @@ export interface Gfx {
    * Create a GPU buffer.
    * @param desc - Buffer descriptor.
    * @returns An opaque buffer handle.
+   * @remarks Caller must call {@link destroyBuffer} when the buffer is no longer needed.
    */
   makeBuffer(desc: BufferDesc): SgBuffer;
 
@@ -587,6 +613,7 @@ export interface Gfx {
    * Create a GPU image (texture).
    * @param desc - Image descriptor.
    * @returns An opaque image handle.
+   * @remarks Caller must call {@link destroyImage} when the image is no longer needed.
    */
   makeImage(desc: ImageDesc): SgImage;
 
@@ -594,6 +621,7 @@ export interface Gfx {
    * Create a GPU sampler.
    * @param desc - Sampler descriptor.
    * @returns An opaque sampler handle.
+   * @remarks Caller must call {@link destroySampler} when the sampler is no longer needed.
    */
   makeSampler(desc: SamplerDesc): SgSampler;
 
@@ -604,6 +632,7 @@ export interface Gfx {
    *
    * @param desc - Shader descriptor with WGSL source.
    * @returns An opaque shader handle.
+   * @remarks Caller must call {@link destroyShader} when the shader is no longer needed.
    */
   makeShader(desc: ShaderDesc): Promise<SgShader>;
 
@@ -611,6 +640,7 @@ export interface Gfx {
    * Create a render pipeline.
    * @param desc - Pipeline descriptor.
    * @returns An opaque pipeline handle.
+   * @remarks Caller must call {@link destroyPipeline} when the pipeline is no longer needed.
    */
   makePipeline(desc: PipelineDesc): SgPipeline;
 
@@ -715,6 +745,10 @@ export interface Gfx {
    * alignment (WebGPU requirement for dynamic offsets).
    *
    * @param data - Uniform data to upload.
+   * @remarks Each call reserves `Math.max(data.byteLength, 256)` bytes,
+   * rounded up to the next 256-byte boundary. The 64 KB per-frame budget
+   * therefore allows at most 256 uniform calls per frame at minimum size.
+   * Exceeding this budget throws at runtime.
    */
   applyUniforms(data: ArrayBufferView): void;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -745,10 +745,10 @@ export interface Gfx {
    * alignment (WebGPU requirement for dynamic offsets).
    *
    * @param data - Uniform data to upload.
-   * @remarks Each call reserves `Math.max(data.byteLength, 256)` bytes,
-   * rounded up to the next 256-byte boundary. The 64 KB per-frame budget
-   * therefore allows at most 256 uniform calls per frame at minimum size.
-   * Exceeding this budget throws at runtime.
+   * @remarks Each call aligns the write offset to a 256-byte boundary,
+   * then reserves `Math.max(data.byteLength, 256)` bytes. The 64 KB
+   * per-frame budget therefore allows at most 256 uniform calls per frame
+   * at minimum size. Exceeding this budget throws at runtime.
    */
   applyUniforms(data: ArrayBufferView): void;
 


### PR DESCRIPTION
## Summary
Documents the two main footguns for sokol-ts users: manual handle lifetime with fixed-size pools, and 256-byte uniform buffer alignment with a 64 KB per-frame budget.

## Changes
- Added "Gotchas" section to README.md between "Features" and "Development" with two subsections: handle lifetime and uniform buffer alignment
- Added `@remarks` tags to all five handle interfaces (SgBuffer, SgImage, SgSampler, SgShader, SgPipeline) in src/types.ts noting manual lifetime
- Added `@remarks` tags to all five `make*` methods on the Gfx interface noting destroy responsibility
- Expanded `applyUniforms` TSDoc with slot-size formula and per-frame budget details

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| README contains Gotchas section after Features, before Development | Done | Section added at the correct location |
| Handle-lifetime paragraph explains manual management, no GC, destroy, pool size, shutdown warns | Done | First subsection covers all points |
| Uniform-alignment paragraph explains 256-byte alignment, 64 KB budget, effective slot size | Done | Second subsection covers all points |
| TSDoc on make* methods gains @remarks for destroy responsibility | Done | All five make* methods updated |
| TSDoc on handle interfaces gains @remarks for manual lifetime | Done | All five interfaces updated |
| TSDoc on applyUniforms gains @remarks for 256-byte slot and budget | Done | @remarks added with formula and limit |
| No code changes (documentation only) | Done | Only README.md and src/types.ts TSDoc modified |

## Test Plan
- `npx tsc --noEmit` passes with zero errors (verified)
- README Gotchas section reads clearly and is positioned correctly
- No existing markdown anchors broken (no anchors reference the new section)

Closes #81