### PR TITLE
fix: correct uniform staging buffer limits and bind group size

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -106,7 +106,9 @@ export async function run(desc: AppDesc): Promise<() => void> {
 
   resize();
 
-  const gfx = createGfx(device, canvas, context, format);
+  const gfx = createGfx(device, canvas, context, format, {
+    uniformBufferSize: desc.uniformBufferSize,
+  });
 
   // Hoist running flag so the device.lost handler can reference it
   let running = true;

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -352,6 +352,7 @@ interface PipelineSlot {
  * @param canvas - The `HTMLCanvasElement` to render into.
  * @param context - The `GPUCanvasContext` obtained from the canvas.
  * @param format - The preferred swapchain texture format (e.g. from `navigator.gpu.getPreferredCanvasFormat()`).
+ * @param options - Optional configuration. `uniformBufferSize` sets the per-frame uniform staging buffer size (default 4 MB).
  * @returns A fully initialised {@link Gfx} instance.
  */
 export function createGfx(
@@ -359,6 +360,7 @@ export function createGfx(
   canvas: HTMLCanvasElement,
   context: GPUCanvasContext,
   format: GPUTextureFormat,
+  options?: { uniformBufferSize?: number },
 ): Gfx {
   const bufferPool   = new Pool<BufferSlot>(128);
   const imagePool    = new Pool<ImageSlot>(128);
@@ -385,10 +387,14 @@ export function createGfx(
   // Texture/sampler bind group cache (group 1): keyed on "pipelineId:img1,img2,...:smp1,smp2,..."
   const textureSamplerBindGroupCache = new Map<string, GPUBindGroup>();
 
-  const UNIFORM_BUFFER_SIZE = 65536; // 64KB uniform staging per ring slot
-  if (UNIFORM_BUFFER_SIZE > device.limits.maxUniformBufferBindingSize) {
+  const DEFAULT_UNIFORM_BUFFER_SIZE = 4 * 1024 * 1024; // 4 MB, matching upstream sokol-C
+  const UNIFORM_BUFFER_SIZE = options?.uniformBufferSize ?? DEFAULT_UNIFORM_BUFFER_SIZE;
+  // The per-slot binding size (256 bytes) is the window exposed to the shader
+  // via dynamic offsets. Validate that this fits within the device limit.
+  const UNIFORM_SLOT_SIZE = 256;
+  if (UNIFORM_SLOT_SIZE > device.limits.maxUniformBufferBindingSize) {
     throw new Error(
-      `UNIFORM_BUFFER_SIZE (${UNIFORM_BUFFER_SIZE}) exceeds device limit maxUniformBufferBindingSize (${device.limits.maxUniformBufferBindingSize})`
+      `Uniform slot size (${UNIFORM_SLOT_SIZE}) exceeds device limit maxUniformBufferBindingSize (${device.limits.maxUniformBufferBindingSize})`
     );
   }
   let uniformFrameIndex = 0;
@@ -414,7 +420,7 @@ export function createGfx(
     uniformBuffers.push(buf);
     uniformBindGroups.push(device.createBindGroup({
       layout: uniformBindGroupLayout,
-      entries: [{ binding: 0, resource: { buffer: buf, size: UNIFORM_BUFFER_SIZE } }],
+      entries: [{ binding: 0, resource: { buffer: buf, size: UNIFORM_SLOT_SIZE } }],
       label: `uniform_bind_group_${i}`,
     }));
   }
@@ -1094,7 +1100,6 @@ export function createGfx(
       };
 
       passEncoder = encoder.beginRenderPass(passDescGpu);
-      uniformOffset = 0;
       boundVertexBuffers = [];
       boundIndexBuffer = null;
       _frameStats = { drawCalls: 0, totalElements: 0, indirectDrawCalls: 0 };
@@ -1177,7 +1182,7 @@ export function createGfx(
       if (alignedOffset + slotSize > UNIFORM_BUFFER_SIZE) {
         throw new Error(
           `Uniform buffer overflow: offset ${alignedOffset} + ${slotSize} exceeds UNIFORM_BUFFER_SIZE (${UNIFORM_BUFFER_SIZE}). ` +
-          `Too many applyUniforms calls in a single pass.`
+          `Too many applyUniforms calls in a single frame.`
         );
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -556,6 +556,14 @@ export interface AppDesc {
   postFrame?: (gfx: Gfx) => void;
   /** Target frames per second. When set, frame callbacks are throttled to this rate. */
   targetFps?: number;
+  /**
+   * Size in bytes of the per-frame uniform staging buffer. Each frame uses one
+   * ring slot of this size; all `applyUniforms` calls within a single frame
+   * (across all passes) must fit. Must be a multiple of 256.
+   *
+   * Default: `4 * 1024 * 1024` (4 MB), matching upstream sokol-C.
+   */
+  uniformBufferSize?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes multiple issues with the uniform staging buffer: undersized default, incorrect bind group size field, per-pass scope instead of per-frame, and broken validation. Also adds a configurable `uniformBufferSize` option to `AppDesc`.

## Changes
- Increase default uniform buffer from 64 KB to 4 MB (matching upstream sokol-C)
- Fix bind group `size` field from full buffer size to per-slot size (256 bytes) -- this was the critical bug that would cause WebGPU validation errors with larger buffers
- Change `uniformOffset` reset from `beginPass` (per-pass) to `commit` only (per-frame), matching upstream sokol-C semantics
- Replace incorrect `maxUniformBufferBindingSize` validation (was comparing total buffer size; now validates per-slot binding size)
- Add `uniformBufferSize` option to `AppDesc` and thread it through `app.ts` to `createGfx`
- Update overflow error message to say "per frame" instead of "per pass"

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default uniform buffer size is 4 MB | Done | `DEFAULT_UNIFORM_BUFFER_SIZE = 4 * 1024 * 1024` |
| Validation checks per-slot binding size, not total buffer | Done | Guard now compares `UNIFORM_SLOT_SIZE` (256) against `maxUniformBufferBindingSize` |
| Bind group `size` field uses per-slot size (256) | Done | Changed from `UNIFORM_BUFFER_SIZE` to `UNIFORM_SLOT_SIZE` at bind group creation |
| `uniformOffset` reset only in `commit()` | Done | Removed reset from `beginPass`; kept in `commit` |
| `AppDesc` gains `uniformBufferSize` field | Done | Added with JSDoc in `types.ts` |
| `createGfx` accepts and uses configurable size | Done | New `options` parameter with fallback to 4 MB default |
| Overflow error says "per frame" | Done | Updated string literal |
| No regressions | Done | `pnpm check:ci` passes, all 93 tests pass |

## Test Plan
- `pnpm check:ci` passes (tsc, lint, build)
- All 93 existing unit tests pass
- Type check clean with `tsc --noEmit`

Closes #82