### PR TITLE
feat: add cube-array texture dimension and fix bind group layout view dimensions

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -437,6 +437,7 @@ export function createGfx(
       colors: desc.colors,
       depth: desc.depth,
       images: desc.images,
+      imageViewDimensions: desc.imageViewDimensions,
       samplerCount: desc.samplerCount,
       multisample: desc.multisample,
     });
@@ -564,6 +565,7 @@ export function createGfx(
       const dim: TextureDimension = desc.dimension ?? "2d";
       const is3D = dim === "3d";
       const isCube = dim === "cube";
+      const isCubeArray = dim === "cube-array";
 
       // Validate compressed format feature support
       const requiredFeature = requiredFeatureForFormat(desc.format ?? PixelFormat.RGBA8);
@@ -576,7 +578,9 @@ export function createGfx(
 
       // Resolve depth/array layers
       let depthOrArrayLayers: number;
-      if (isCube) {
+      if (isCubeArray) {
+        depthOrArrayLayers = (desc.numSlices ?? 1) * 6;
+      } else if (isCube) {
         depthOrArrayLayers = 6;
       } else if (is3D) {
         depthOrArrayLayers = desc.depth ?? 1;
@@ -603,6 +607,7 @@ export function createGfx(
         usage |= GPUTextureUsage.RENDER_ATTACHMENT;
       }
 
+      // Both cube and cube-array use "2d" as the underlying GPU texture dimension
       const gpuDimension: GPUTextureDimension = is3D ? "3d" : "2d";
 
       const texture = device.createTexture({
@@ -627,7 +632,9 @@ export function createGfx(
 
       // Create the appropriate texture view
       let viewDimension: GPUTextureViewDimension;
-      if (isCube) {
+      if (isCubeArray) {
+        viewDimension = "cube-array";
+      } else if (isCube) {
         viewDimension = "cube";
       } else if (is3D) {
         viewDimension = "3d";
@@ -758,10 +765,11 @@ export function createGfx(
       if (imageCount > 0 || samplerCount > 0) {
         const group1Entries: GPUBindGroupLayoutEntry[] = [];
         for (let i = 0; i < imageCount; i++) {
+          const viewDim = desc.imageViewDimensions?.[i];
           group1Entries.push({
             binding: i,
             visibility: GPUShaderStage.FRAGMENT,
-            texture: {},
+            texture: viewDim ? { viewDimension: viewDim } : {},
           });
         }
         for (let i = 0; i < samplerCount; i++) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,7 +257,7 @@ export enum BufferUsage {
   INDIRECT  = 3,
 }
 
-export type TextureDimension = "2d" | "3d" | "cube";
+export type TextureDimension = "2d" | "3d" | "cube" | "cube-array";
 
 // ---------------------------------------------------------------------------
 // Desc structs -- all fields optional, defaults applied at creation
@@ -295,7 +295,12 @@ export interface ImageDesc {
   dimension?: TextureDimension;
   /** Number of mipmaps. 0 = auto-generate full chain, 1 = no mipmaps (default). */
   numMipmaps?: number;
-  /** Number of array layers for 2D array textures (default 1). Ignored for "cube" (always 6). */
+  /**
+   * Number of array layers for 2D array textures (default 1).
+   * Ignored for "cube" (always 6 layers).
+   * For "cube-array", this is the number of cubes; the actual layer count
+   * will be `numSlices * 6`.
+   */
   numSlices?: number;
   /** Debug label for GPU debugging tools. */
   label?: string;
@@ -442,6 +447,16 @@ export interface PipelineDesc {
   depth?: DepthStencilDesc;
   /** Number of texture bindings in bind group 1 (locations 0..images-1). Default: 0. */
   images?: number;
+  /**
+   * View dimension for each texture binding in bind group 1.
+   * When provided, `imageViewDimensions[i]` sets the `viewDimension` on the
+   * bind group layout entry for image slot `i`. Slots beyond the array length
+   * (or when omitted entirely) default to `"2d"`.
+   *
+   * Must be set for cube / cube-array textures; otherwise the layout defaults
+   * to `"2d"` and `createBindGroup` will fail at runtime.
+   */
+  imageViewDimensions?: GPUTextureViewDimension[];
   /** Number of sampler bindings in bind group 1 (locations images..images+samplerCount-1). Default: 0. */
   samplerCount?: number;
   /** MSAA multisample configuration. */


### PR DESCRIPTION
## Summary
Add support for cube map array textures and fix the bind group layout to support non-2d texture view dimensions. The layout previously hard-coded the default "2d" view dimension, which is a latent bug for cube textures as well.

## Changes
- Add `"cube-array"` to the `TextureDimension` union type
- Update `makeImage()` to compute `depthOrArrayLayers = numSlices * 6` for cube-array textures
- Update `makeImage()` to create views with `dimension: "cube-array"` for cube-array textures
- Add `imageViewDimensions` optional array to `PipelineDesc` for specifying per-slot view dimensions in bind group layouts
- Update `makePipeline()` to pass `viewDimension` to bind group layout entries when `imageViewDimensions` is provided
- Include `imageViewDimensions` in the pipeline cache key
- Update `ImageDesc.numSlices` doc comment to explain cube-array semantics

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `TextureDimension` type includes `"cube-array"` | PASS | Added to union in types.ts |
| `makeImage()` correctly computes `depthOrArrayLayers` as `numSlices * 6` for cube-array | PASS | Added `isCubeArray` branch before `isCube` in layer resolution |
| `makeImage()` creates view with `dimension: "cube-array"` | PASS | Added `isCubeArray` branch in view dimension resolution |
| `GPUTextureDimension` for cube-array is `"2d"` (not `"3d"`) | PASS | Only `is3D` triggers `"3d"`; cube-array falls through to `"2d"` |
| Bind group layout supports non-`"2d"` view dimensions | PASS | `imageViewDimensions` array in PipelineDesc controls per-slot `viewDimension` |
| Mipmap generation works for cube-array textures | PASS | `generateMipmaps` already iterates all `depthOrArrayLayers`; cube-array passes `numSlices * 6` |
| `ImageDesc.numSlices` doc comment updated | PASS | Expanded to explain cube-array semantics |

## Test Plan
- `pnpm check:ci` passes (lint + build)
- All 93 existing unit tests pass via `vitest run`
- TypeScript compilation clean with `tsc --noEmit`

Closes #76