### PR TITLE
docs: remove hardcoded e2e test count from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Each `applyUniforms(data)` call writes into a shared 64 KB ring buffer that is r
 npm install
 npm run lint            # type-check (tsc --noEmit)
 npm test                # unit tests (vitest)
-npm run test:e2e        # e2e tests (playwright, 9 tests -- renders all examples in Chromium)
+npm run test:e2e        # e2e tests (playwright -- renders all examples in Chromium)
 npm run build           # emit to dist/
 npm run docs            # generate TypeDoc API docs
 ```


### PR DESCRIPTION
## Summary
Remove the hardcoded "9 tests" count from the e2e test comment in README.md, matching the pattern established by PR #83 for unit tests.

## Changes
- Remove "9 tests" from the `test:e2e` comment on line 112 of README.md

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The test:e2e comment no longer contains a hardcoded test count | Done | Verified via git diff -- "9 tests" removed |
| The comment remains descriptive (mentions Playwright and rendering examples in Chromium) | Done | Comment now reads: "e2e tests (playwright -- renders all examples in Chromium)" |

## Test Plan
- Manual verification: confirmed README.md no longer contains a hardcoded e2e test count
- No automated tests needed (documentation-only change)

Closes #96