### PR TITLE
fix: move _frameStats reset from beginPass to commit for multi-pass accumulation

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1330,7 +1330,6 @@ export function createGfx(
       passEncoder = encoder.beginRenderPass(passDescGpu);
       boundVertexBuffers = [];
       boundIndexBuffer = null;
-      _frameStats = { drawCalls: 0, totalElements: 0, indirectDrawCalls: 0, dispatchCalls: 0 };
     },
 
     applyPipeline(pip: SgPipeline) {
@@ -1587,6 +1586,7 @@ export function createGfx(
       frameTime = (now - lastFrameTime) / 1000;
       lastFrameTime = now;
       _frameCount++;
+      _frameStats = { drawCalls: 0, totalElements: 0, indirectDrawCalls: 0, dispatchCalls: 0 };
     },
 
     async rebuildPipelinesForShader(shader: SgShader): Promise<void> {

--- a/tests/compute.test.ts
+++ b/tests/compute.test.ts
@@ -296,18 +296,63 @@ describe("Compute: DrawStats.dispatchCalls", () => {
     gfx.dispatchWorkgroups(1, 1, 1);
     gfx.endPass();
 
-    // frameStats snapshot should reflect 3 dispatches
-    // Note: beginPass resets stats, but beginComputePass does not reset them
-    // directly. The stats are reset at the first beginPass or stay accumulated.
+    // frameStats accumulates across all passes within a frame;
+    // stats are reset in commit(), not beginPass().
     const stats = gfx.frameStats;
     expect(stats.dispatchCalls).toBe(3);
   });
 
-  it("starts dispatchCalls at zero", () => {
+  it("starts dispatchCalls at zero after commit", () => {
     const gfx = makeGfx();
-    // After beginPass (which resets stats), dispatchCalls should be 0
+    // After commit() resets stats, dispatchCalls should be 0
+    gfx.beginComputePass();
+    gfx.endPass();
+    gfx.commit();
+    expect(gfx.frameStats.dispatchCalls).toBe(0);
+  });
+
+  it("accumulates dispatch and draw stats across compute and render passes", async () => {
+    const gfx = makeGfx();
+    const compShd = await gfx.makeComputeShader({
+      source: "@compute @workgroup_size(64) fn cs_main() {}",
+    });
+    const compPip = gfx.makeComputePipeline({ shader: compShd, storageBuffers: 1 });
+    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+
+    // Compute pass: 2 dispatches
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(compPip);
+    gfx.applyComputeBindings({ storageBuffers: [buf] });
+    gfx.dispatchWorkgroups(4);
+    gfx.dispatchWorkgroups(8);
+    gfx.endPass();
+
+    // Render pass: dispatch stats must survive beginPass
     gfx.beginPass();
     gfx.endPass();
-    expect(gfx.frameStats.dispatchCalls).toBe(0);
+
+    const stats = gfx.frameStats;
+    expect(stats.dispatchCalls).toBe(2);
+    expect(stats.drawCalls).toBe(0);
+  });
+
+  it("resets all stats to zero after commit", async () => {
+    const gfx = makeGfx();
+    const shd = await gfx.makeComputeShader({
+      source: "@compute @workgroup_size(64) fn cs_main() {}",
+    });
+    const pip = gfx.makeComputePipeline({ shader: shd });
+
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.dispatchWorkgroups(1);
+    gfx.endPass();
+    gfx.commit();
+
+    const stats = gfx.frameStats;
+    expect(stats.dispatchCalls).toBe(0);
+    expect(stats.drawCalls).toBe(0);
+    expect(stats.totalElements).toBe(0);
+    expect(stats.indirectDrawCalls).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
Moves the `_frameStats` reset from `beginPass()` to `commit()` so that draw and dispatch statistics accumulate across all render and compute passes within a single frame.

## Changes
- Removed `_frameStats` reset from `beginPass()` in `src/gfx.ts` (was line 1333)
- Added `_frameStats` reset to `commit()` in `src/gfx.ts` (after `_frameCount++`)
- Updated existing test comment and "starts dispatchCalls at zero" test to use `commit()` for reset
- Added test: compute + render pass accumulation (dispatch stats survive `beginPass()`)
- Added test: `commit()` resets all stat fields to zero

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| _frameStats accumulates across all beginPass and beginComputePass calls | Pass | New accumulation test verifies dispatchCalls survive a subsequent beginPass |
| _frameStats resets to zero in commit() | Pass | New reset test checks all four fields are zero after commit |
| frameStats returns accumulated totals between endPass and commit | Pass | Accumulation test reads stats after endPass, before commit |
| Multi-pass scenario: two passes report summed stats | Pass | Compute-then-render test confirms 2 dispatchCalls across passes |
| Compute-then-render: dispatch calls survive subsequent beginPass | Pass | Explicit test for this scenario |
| No regression in single-pass rendering | Pass | All 142 existing tests pass |

## Test Plan
- `pnpm check:ci` passes (lint + build)
- All 142 unit tests pass across 6 test files
- 3 new/updated tests in `tests/compute.test.ts` specifically cover multi-pass accumulation and commit-reset behavior

Closes #92