### PR TITLE
refactor: remove unused BufferDesc.access field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -317,13 +317,6 @@ export interface QuerySetDesc {
 export interface BufferDesc {
   /** Buffer usage hint. Default: {@link BufferUsage.IMMUTABLE}. */
   usage?: BufferUsage;
-  /**
-   * Storage buffer access mode. Only relevant when `usage` is {@link BufferUsage.STORAGE}.
-   * - `"read"`: shader can only read (maps to `"read-only-storage"` bind group layout type).
-   * - `"readwrite"`: shader can read and write (maps to `"storage"` bind group layout type).
-   * Default: `"readwrite"`.
-   */
-  access?: "read" | "readwrite";
   /** Initial data to upload. If provided, the buffer size is derived from this. */
   data?: ArrayBufferView;
   /** Buffer size in bytes. Used when `data` is not provided. Default: 256. */

--- a/tests/gfx-pool.test.ts
+++ b/tests/gfx-pool.test.ts
@@ -266,15 +266,9 @@ describe("Buffer: storage buffer creation", () => {
     ).not.toThrow();
   });
 
-  it("creates storage buffer with read access mode", () => {
+  it("creates storage buffer", () => {
     const gfx = makeGfx();
-    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE, access: "read" });
-    expect(gfx.isValid(buf)).toBe(true);
-  });
-
-  it("creates storage buffer with readwrite access mode", () => {
-    const gfx = makeGfx();
-    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE, access: "readwrite" });
+    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
     expect(gfx.isValid(buf)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Remove the unused `BufferDesc.access` field from the interface in `src/types.ts`. This field was introduced in PR #88 but was never consumed by the implementation -- storage buffer access mode is correctly controlled at the pipeline level via `PipelineDesc.storageBufferAccess`.

## Changes
- Removed `access` property and its TSDoc comment from the `BufferDesc` interface in `src/types.ts`
- Consolidated two test cases ("read access mode" and "readwrite access mode") into a single "creates storage buffer" test in `tests/gfx-pool.test.ts`, preserving storage buffer creation coverage

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `BufferDesc.access` field and TSDoc removed from interface | Pass | Removed lines 320-326 from types.ts |
| Tests referencing `access` updated | Pass | Consolidated two tests into one without `access` |
| No references to `BufferDesc.access` remain | Pass | Project-wide grep returns zero matches |
| Existing tests pass | Pass | `npx vitest run` -- 139 tests passed (6 files) |
| Build succeeds with no type errors | Pass | `npx tsc --noEmit` succeeds cleanly |

## Test Plan
- `npx tsc --noEmit` passes with no type errors
- `npx vitest run` passes all 139 tests across 6 test files

Closes #95