### PR TITLE
fix: add guards preventing overlapping render and compute passes

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1236,6 +1236,12 @@ export function createGfx(
     },
 
     beginPass(desc?: PassDesc) {
+      if (passEncoder) {
+        throw new Error("beginPass() called while a render pass is already active -- call endPass() first");
+      }
+      if (computePassEncoder) {
+        throw new Error("beginPass() called while a compute pass is active -- call endPass() first");
+      }
       // Create the encoder once per frame; reuse across multiple passes.
       if (!encoder) {
         encoder = device.createCommandEncoder();
@@ -1505,6 +1511,12 @@ export function createGfx(
     },
 
     beginComputePass(opts?: { label?: string }) {
+      if (passEncoder) {
+        throw new Error("beginComputePass() called while a render pass is active -- call endPass() first");
+      }
+      if (computePassEncoder) {
+        throw new Error("beginComputePass() called while a compute pass is already active -- call endPass() first");
+      }
       if (!encoder) {
         encoder = device.createCommandEncoder();
       }

--- a/tests/compute.test.ts
+++ b/tests/compute.test.ts
@@ -250,6 +250,62 @@ describe("Compute: pass lifecycle", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Overlapping pass guards
+// ---------------------------------------------------------------------------
+
+describe("Compute: overlapping pass guards", () => {
+  it("throws on beginPass while a compute pass is active", () => {
+    const gfx = makeGfx();
+    gfx.beginComputePass();
+    expect(() => gfx.beginPass()).toThrow(
+      "beginPass() called while a compute pass is active -- call endPass() first"
+    );
+  });
+
+  it("throws on beginComputePass while a render pass is active", () => {
+    const gfx = makeGfx();
+    gfx.beginPass();
+    expect(() => gfx.beginComputePass()).toThrow(
+      "beginComputePass() called while a render pass is active -- call endPass() first"
+    );
+  });
+
+  it("throws on beginPass while a render pass is already active", () => {
+    const gfx = makeGfx();
+    gfx.beginPass();
+    expect(() => gfx.beginPass()).toThrow(
+      "beginPass() called while a render pass is already active -- call endPass() first"
+    );
+  });
+
+  it("throws on beginComputePass while a compute pass is already active", () => {
+    const gfx = makeGfx();
+    gfx.beginComputePass();
+    expect(() => gfx.beginComputePass()).toThrow(
+      "beginComputePass() called while a compute pass is already active -- call endPass() first"
+    );
+  });
+
+  it("allows beginPass after endPass closes a compute pass", () => {
+    const gfx = makeGfx();
+    gfx.beginComputePass();
+    gfx.endPass();
+    expect(() => gfx.beginPass()).not.toThrow();
+    gfx.endPass();
+    gfx.commit();
+  });
+
+  it("allows beginComputePass after endPass closes a render pass", () => {
+    const gfx = makeGfx();
+    gfx.beginPass();
+    gfx.endPass();
+    expect(() => gfx.beginComputePass()).not.toThrow();
+    gfx.endPass();
+    gfx.commit();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Compute and render pass coexistence
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Add fail-fast guards in `beginPass()` and `beginComputePass()` that throw descriptive errors if another pass type (or the same pass type) is already active. This prevents undefined behavior from overlapping WebGPU pass encoders, bringing sokol-ts in line with the C sokol_gfx library's `in_pass` validation pattern.

## Changes
- Added guard in `beginPass()` that throws if `passEncoder` or `computePassEncoder` is non-null
- Added guard in `beginComputePass()` that throws if `passEncoder` or `computePassEncoder` is non-null
- Added 6 new tests: 4 overlap scenarios (render-during-compute, compute-during-render, double-render, double-compute) and 2 edge-case tests confirming endPass() properly clears state for subsequent passes

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| beginPass() throws if computePassEncoder is non-null | Pass | Test: "throws on beginPass while a compute pass is active" |
| beginPass() throws if passEncoder is non-null | Pass | Test: "throws on beginPass while a render pass is already active" |
| beginComputePass() throws if passEncoder is non-null | Pass | Test: "throws on beginComputePass while a render pass is active" |
| beginComputePass() throws if computePassEncoder is non-null | Pass | Test: "throws on beginComputePass while a compute pass is already active" |
| Error messages name conflicting pass type and suggest endPass() | Pass | All messages follow pattern: "[fn]() called while [type] is [already] active -- call endPass() first" |
| Existing tests continue to pass | Pass | All 146 tests pass including coexistence test at compute.test.ts:256 |

## Test Plan
- `npx vitest run` -- all 146 tests pass (6 new + 140 existing)
- `npx tsc --noEmit` -- clean type check

Closes #93