### PR TITLE
feat: cache compute bind groups to avoid redundant GPU allocations

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -412,6 +412,7 @@ export function createGfx(
   let passEncoder: GPURenderPassEncoder | null = null;
   let computePassEncoder: GPUComputePassEncoder | null = null;
   let currentComputePipeline: ComputePipelineSlot | null = null;
+  let currentComputePipelineId = 0;
   let currentPipeline: PipelineSlot | null = null;
   let currentPipelineId = 0;
   let frameTime = 0;
@@ -424,6 +425,9 @@ export function createGfx(
 
   // Texture/sampler bind group cache (group 1): keyed on "pipelineId:img1,img2,...:smp1,smp2,..."
   const textureSamplerBindGroupCache = new Map<string, GPUBindGroup>();
+
+  // Compute bind group cache: keyed on "computePipelineId:sbuf1,sbuf2,..."
+  const computeBindGroupCache = new Map<string, GPUBindGroup>();
 
   const DEFAULT_UNIFORM_BUFFER_SIZE = 4 * 1024 * 1024; // 4 MB, matching upstream sokol-C
   const UNIFORM_BUFFER_SIZE = options?.uniformBufferSize ?? DEFAULT_UNIFORM_BUFFER_SIZE;
@@ -593,11 +597,35 @@ export function createGfx(
     }
   }
 
+  function invalidateComputeCacheForBuffer(resourceId: number) {
+    // Compute cache keys have the form "computePipelineId:sbuf1,sbuf2,..."
+    const idStr = String(resourceId);
+    for (const key of computeBindGroupCache.keys()) {
+      const colonIdx = key.indexOf(":");
+      const segment = key.substring(colonIdx + 1);
+      if (segment) {
+        const ids = segment.split(",");
+        if (ids.includes(idStr)) {
+          computeBindGroupCache.delete(key);
+        }
+      }
+    }
+  }
+
   function invalidateCachesForPipeline(pipelineId: number) {
     const prefix = `${pipelineId}:`;
     for (const key of textureSamplerBindGroupCache.keys()) {
       if (key.startsWith(prefix)) {
         textureSamplerBindGroupCache.delete(key);
+      }
+    }
+  }
+
+  function invalidateComputeCacheForPipeline(pipelineId: number) {
+    const prefix = `${pipelineId}:`;
+    for (const key of computeBindGroupCache.keys()) {
+      if (key.startsWith(prefix)) {
+        computeBindGroupCache.delete(key);
       }
     }
   }
@@ -1064,6 +1092,7 @@ export function createGfx(
     destroyBuffer(buf: SgBuffer) {
       // Invalidate any cached bind groups referencing this buffer as a storage buffer
       invalidateTextureSamplerCacheForResource(buf.id, "sbuf");
+      invalidateComputeCacheForBuffer(buf.id);
       const slot = bufferPool.free(buf.id);
       if (slot) slot.gpu.destroy();
     },
@@ -1102,6 +1131,7 @@ export function createGfx(
       pipelinePool.free(pip.id);
     },
     destroyComputePipeline(pip: SgPipeline) {
+      invalidateComputeCacheForPipeline(pip.id);
       computePipelinePool.free(pip.id);
     },
 
@@ -1205,6 +1235,9 @@ export function createGfx(
     },
 
     shutdown() {
+      textureSamplerBindGroupCache.clear();
+      computeBindGroupCache.clear();
+
       for (const slot of bufferPool.liveResources())   { slot.gpu.destroy(); }
       for (const slot of imagePool.liveResources())    { slot.texture.destroy(); }
       for (const slot of querySetPool.liveResources()) { slot.gpu.destroy(); }
@@ -1519,6 +1552,7 @@ export function createGfx(
       if (!slot || !computePassEncoder) throw new Error("Invalid compute pipeline or no active compute pass");
       computePassEncoder.setPipeline(slot.gpu);
       currentComputePipeline = slot;
+      currentComputePipelineId = pip.id;
     },
 
     applyComputeBindings(bind: ComputeBindings) {
@@ -1529,16 +1563,25 @@ export function createGfx(
         if (!currentComputePipeline.storageBindGroupLayout) {
           throw new Error("Compute pipeline has no storage buffer bindings configured");
         }
-        const entries: GPUBindGroupEntry[] = [];
-        for (let i = 0; i < storageHandles.length; i++) {
-          const buf = bufferPool.get(storageHandles[i].id);
-          if (!buf) throw new Error(`Invalid storage buffer at binding ${i}`);
-          entries.push({ binding: i, resource: { buffer: buf.gpu } });
+
+        // Build cache key from compute pipeline id + storage buffer ids
+        const sbufIds = storageHandles.map(h => h.id).join(",");
+        const cacheKey = `${currentComputePipelineId}:${sbufIds}`;
+
+        let bg = computeBindGroupCache.get(cacheKey);
+        if (!bg) {
+          const entries: GPUBindGroupEntry[] = [];
+          for (let i = 0; i < storageHandles.length; i++) {
+            const buf = bufferPool.get(storageHandles[i].id);
+            if (!buf) throw new Error(`Invalid storage buffer at binding ${i}`);
+            entries.push({ binding: i, resource: { buffer: buf.gpu } });
+          }
+          bg = device.createBindGroup({
+            layout: currentComputePipeline.storageBindGroupLayout,
+            entries,
+          });
+          computeBindGroupCache.set(cacheKey, bg);
         }
-        const bg = device.createBindGroup({
-          layout: currentComputePipeline.storageBindGroupLayout,
-          entries,
-        });
         // Storage buffers go to group 1 if uniforms are used, group 0 otherwise
         const groupIndex = currentComputePipeline.desc.uniforms ? 1 : 0;
         computePassEncoder.setBindGroup(groupIndex, bg);
@@ -1568,6 +1611,7 @@ export function createGfx(
         computePassEncoder.end();
         computePassEncoder = null;
         currentComputePipeline = null;
+        currentComputePipelineId = 0;
       }
     },
 

--- a/tests/compute.test.ts
+++ b/tests/compute.test.ts
@@ -3,7 +3,7 @@
  * Tests exercise the public createGfx() API using mock GPU objects.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createGfx } from "../src/gfx.js";
 import { BufferUsage } from "../src/types.js";
 import { createMockGfxDeps } from "./gpu-mock.js";
@@ -309,5 +309,136 @@ describe("Compute: DrawStats.dispatchCalls", () => {
     gfx.beginPass();
     gfx.endPass();
     expect(gfx.frameStats.dispatchCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compute bind group caching
+// ---------------------------------------------------------------------------
+
+describe("Compute: bind group caching", () => {
+  function makeGfxWithSpy() {
+    const deps = createMockGfxDeps();
+    const spy = vi.spyOn(deps.device, "createBindGroup");
+    const gfx = createGfx(deps.device, deps.canvas, deps.context, deps.format);
+    return { gfx, createBindGroupSpy: spy };
+  }
+
+  it("caches bind group on repeated identical bindings", async () => {
+    const { gfx, createBindGroupSpy } = makeGfxWithSpy();
+    const shd = await gfx.makeComputeShader({
+      source: "@compute @workgroup_size(64) fn cs_main() {}",
+    });
+    const pip = gfx.makeComputePipeline({ shader: shd, storageBuffers: 1 });
+    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+
+    // First call -- cache miss, creates bind group
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf] });
+    gfx.endPass();
+
+    const callsAfterFirst = createBindGroupSpy.mock.calls.length;
+
+    // Second call -- cache hit, should NOT create another bind group
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf] });
+    gfx.endPass();
+    gfx.commit();
+
+    expect(createBindGroupSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("creates a new bind group when bindings change", async () => {
+    const { gfx, createBindGroupSpy } = makeGfxWithSpy();
+    const shd = await gfx.makeComputeShader({
+      source: "@compute @workgroup_size(64) fn cs_main() {}",
+    });
+    const pip = gfx.makeComputePipeline({ shader: shd, storageBuffers: 1 });
+    const buf1 = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+    const buf2 = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf1] });
+    gfx.endPass();
+
+    const callsAfterFirst = createBindGroupSpy.mock.calls.length;
+
+    // Different buffer -- should create a new bind group
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf2] });
+    gfx.endPass();
+    gfx.commit();
+
+    expect(createBindGroupSpy.mock.calls.length).toBe(callsAfterFirst + 1);
+  });
+
+  it("invalidates cache when storage buffer is destroyed", async () => {
+    const { gfx, createBindGroupSpy } = makeGfxWithSpy();
+    const shd = await gfx.makeComputeShader({
+      source: "@compute @workgroup_size(64) fn cs_main() {}",
+    });
+    const pip = gfx.makeComputePipeline({ shader: shd, storageBuffers: 1 });
+    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+
+    // Populate cache
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf] });
+    gfx.endPass();
+    gfx.commit();
+
+    const callsAfterFirst = createBindGroupSpy.mock.calls.length;
+
+    // Destroy buffer -- invalidates cache
+    gfx.destroyBuffer(buf);
+
+    // Create a new buffer (will get same or different slot id)
+    const buf2 = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf2] });
+    gfx.endPass();
+    gfx.commit();
+
+    // Should have created a new bind group since the old one was invalidated
+    expect(createBindGroupSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it("invalidates cache when compute pipeline is destroyed", async () => {
+    const { gfx, createBindGroupSpy } = makeGfxWithSpy();
+    const shd = await gfx.makeComputeShader({
+      source: "@compute @workgroup_size(64) fn cs_main() {}",
+    });
+    const pip = gfx.makeComputePipeline({ shader: shd, storageBuffers: 1 });
+    const buf = gfx.makeBuffer({ size: 256, usage: BufferUsage.STORAGE });
+
+    // Populate cache
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip);
+    gfx.applyComputeBindings({ storageBuffers: [buf] });
+    gfx.endPass();
+    gfx.commit();
+
+    const callsAfterFirst = createBindGroupSpy.mock.calls.length;
+
+    // Destroy pipeline -- invalidates cache
+    gfx.destroyComputePipeline(pip);
+
+    // Recreate pipeline and rebind
+    const pip2 = gfx.makeComputePipeline({ shader: shd, storageBuffers: 1 });
+
+    gfx.beginComputePass();
+    gfx.applyComputePipeline(pip2);
+    gfx.applyComputeBindings({ storageBuffers: [buf] });
+    gfx.endPass();
+    gfx.commit();
+
+    // Should have created a new bind group since old pipeline was destroyed
+    expect(createBindGroupSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
   });
 });


### PR DESCRIPTION
## Summary

`applyComputeBindings()` was calling `device.createBindGroup()` unconditionally on every invocation, even when the same pipeline and storage buffers were bound. This adds a `computeBindGroupCache` that follows the existing `textureSamplerBindGroupCache` pattern from the render path.

## Changes

- Added `computeBindGroupCache` (`Map<string, GPUBindGroup>`) keyed by `"{computePipelineId}:{sbufId1},{sbufId2},..."`
- Added `currentComputePipelineId` state variable, set in `applyComputePipeline`, reset in `endPass`
- Modified `applyComputeBindings` to check cache before calling `device.createBindGroup()`
- Added `invalidateComputeCacheForBuffer()` helper, called from `destroyBuffer`
- Added `invalidateComputeCacheForPipeline()` helper, called from `destroyComputePipeline`
- Both caches cleared in `shutdown()`
- Added 4 unit tests: cache hit, cache miss on different bindings, invalidation on buffer destroy, invalidation on pipeline destroy

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Returns cached GPUBindGroup for same pipeline+buffers | Pass | Unit test: spy confirms createBindGroup called once for two identical applyComputeBindings calls |
| createBindGroup called only once for repeated bindings | Pass | Unit test with vi.spyOn call count assertion |
| Cache invalidated on storage buffer destroy | Pass | Unit test: destroyBuffer triggers new createBindGroup on rebind |
| Cache invalidated on compute pipeline destroy | Pass | Unit test: destroyComputePipeline triggers new createBindGroup on rebind |
| Cache cleared on shutdown | Pass | textureSamplerBindGroupCache.clear() and computeBindGroupCache.clear() called at top of shutdown() |
| Existing compute tests pass | Pass | All 144 tests pass |
| No regression in render path caching | Pass | All existing tests pass unchanged |

## Test Plan

- `npx vitest run` -- all 144 tests pass (6 test files)
- TypeScript compiles cleanly (`npx tsc --noEmit`)

Closes #94