### PR TITLE
refactor: remove unused SaudioStream interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1131,13 +1131,6 @@ export interface AudioDesc {
 }
 
 /**
- * Reserved handle for future multi-stream audio support.
- *
- * Currently unused; the initial implementation uses one stream per Audio instance.
- */
-export interface SaudioStream { readonly _brand: "SaudioStream"; readonly id: number }
-
-/**
  * Audio playback context returned by {@link createAudio}.
  *
  * Manages an AudioWorklet-based audio pipeline with automatic


### PR DESCRIPTION
## Summary
Remove the dead `SaudioStream` interface from `src/types.ts`. It was speculative scaffolding for multi-stream audio support that was never implemented or referenced anywhere in the codebase.

## Changes
- Removed the `SaudioStream` interface and its 5-line JSDoc comment from `src/types.ts` (6 lines total)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SaudioStream interface and JSDoc removed from types.ts | Done | Deleted lines 1133-1138 |
| No references to SaudioStream anywhere in repo | Done | `grep -rn SaudioStream src/ tests/ examples/` returns no results |
| `npm run build` succeeds | Done | `tsc --noEmit` passes with no errors |
| `npm test` passes with no regressions | Done | 151 tests pass across 6 test files |

## Test Plan
- Verified no remaining references with grep
- TypeScript compilation succeeds
- All 151 existing tests pass unchanged

Closes #102